### PR TITLE
chore: add workflow to check dependencies

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Generate Dependencies file
-        run: java -jar ./scripts/download/org.eclipse.dash.licenses-0.0.1-SNAPSHOT.jar yarn.lock -project automotive.tractusx -summary DEPENDENCIES
+        run: java -jar ./scripts/download/org.eclipse.dash.licenses-1.0.3-SNAPSHOT.jar yarn.lock -project automotive.tractusx -summary DEPENDENCIES
 
       - name: Check if dependencies were changed
         id: dependencies-changed

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -1,0 +1,79 @@
+###############################################################
+# Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################
+
+name: Check Dependencies
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+jobs:
+  check-dependencies:
+
+    runs-on: ubuntu-latest
+
+    steps:
+  
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Generate Dependencies file
+        run: java -jar ./scripts/download/org.eclipse.dash.licenses-0.0.1-SNAPSHOT.jar yarn.lock -project automotive.tractusx -summary DEPENDENCIES
+
+      - name: Check if dependencies were changed
+        id: dependencies-changed
+        run: |
+          changed=$(git diff DEPENDENCIES)
+          if [[ -n "$changed" ]]; then
+            echo "dependencies changed"
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "dependencies not changed"
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check for restricted dependencies
+        run: |
+          restricted=$(grep ' restricted,' DEPENDENCIES || true)
+          if [[ -n "$restricted" ]]; then
+            echo "The following dependencies are restricted: $restricted"
+            exit 1
+          fi
+        if: steps.dependencies-changed.outputs.changed == 'true'
+
+      - name: Upload DEPENDENCIES file
+        uses: actions/upload-artifact@v3
+        with:
+          path: DEPENDENCIES
+        if: steps.dependencies-changed.outputs.changed == 'true'
+
+      - name: Signal need to update DEPENDENCIES
+        run: |
+          echo "Dependencies need to be updated (updated DEPENDENCIES file has been uploaded to workflow run)"
+          exit 1
+        if: steps.dependencies-changed.outputs.changed == 'true'

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,4811 +1,1401 @@
-yarn licenses v1.22.19
-├─ (Apache-2.0 OR MPL-1.1)
-│  └─ harmony-reflect@1.6.2
-│     ├─ URL: https://tvcutsem@github.com/tvcutsem/harmony-reflect.git
-│     └─ VendorUrl: https://github.com/tvcutsem/harmony-reflect
-├─ (MIT OR CC0-1.0)
-│  ├─ type-fest@0.16.0
-│  │  ├─ URL: https://github.com/sindresorhus/type-fest.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ type-fest@0.20.2
-│  │  ├─ URL: https://github.com/sindresorhus/type-fest.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ type-fest@0.21.3
-│  │  ├─ URL: https://github.com/sindresorhus/type-fest.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ type-fest@0.6.0
-│  │  ├─ URL: https://github.com/sindresorhus/type-fest.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ type-fest@0.8.1
-│  │  ├─ URL: https://github.com/sindresorhus/type-fest.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  └─ type-fest@2.19.0
-│     ├─ URL: https://github.com/sindresorhus/type-fest.git
-│     ├─ VendorName: Sindre Sorhus
-│     └─ VendorUrl: https://sindresorhus.com
-├─ (MIT OR GPL-3.0)
-│  └─ store2@2.14.2
-│     ├─ URL: http://github.com/nbubna/store.git
-│     ├─ VendorName: Nathan Bubna
-│     └─ VendorUrl: http://www.esha.com/
-├─ 0BSD
-│  ├─ tslib@1.14.1
-│  │  ├─ URL: https://github.com/Microsoft/tslib.git
-│  │  ├─ VendorName: Microsoft Corp.
-│  │  └─ VendorUrl: https://www.typescriptlang.org/
-│  └─ tslib@2.5.3
-│     ├─ URL: https://github.com/Microsoft/tslib.git
-│     ├─ VendorName: Microsoft Corp.
-│     └─ VendorUrl: https://www.typescriptlang.org/
-├─ Apache-2.0
-│  ├─ @ampproject/remapping@2.2.1
-│  │  ├─ URL: git+https://github.com/ampproject/remapping.git
-│  │  └─ VendorName: Justin Ridgewell
-│  ├─ @humanwhocodes/config-array@0.11.10
-│  │  ├─ URL: git+https://github.com/humanwhocodes/config-array.git
-│  │  ├─ VendorName: Nicholas C. Zakas
-│  │  └─ VendorUrl: https://github.com/humanwhocodes/config-array#readme
-│  ├─ @humanwhocodes/module-importer@1.0.1
-│  │  ├─ URL: git+https://github.com/humanwhocodes/module-importer.git
-│  │  └─ VendorName: Nicholas C. Zaks
-│  ├─ @juggle/resize-observer@3.4.0
-│  │  ├─ URL: git+ssh://git@github.com/juggle/resize-observer.git
-│  │  ├─ VendorName: Juggle
-│  │  └─ VendorUrl: https://juggle.studio/resize-observer/
-│  ├─ @webassemblyjs/leb128@1.11.6
-│  │  └─ URL: https://github.com/xtuc/webassemblyjs.git
-│  ├─ @xtuc/long@4.2.2
-│  │  ├─ URL: https://github.com/dcodeIO/long.js.git
-│  │  └─ VendorName: Daniel Wirtz
-│  ├─ ansi-html-community@0.0.8
-│  │  ├─ URL: git://github.com/mahdyar/ansi-html-community.git
-│  │  ├─ VendorName: mahdyar
-│  │  └─ VendorUrl: https://github.com/mahdyar/ansi-html-community
-│  ├─ aria-query@5.1.3
-│  │  ├─ URL: git+https://github.com/A11yance/aria-query.git
-│  │  ├─ VendorName: Jesse Beach
-│  │  └─ VendorUrl: https://github.com/A11yance/aria-query#readme
-│  ├─ bser@2.1.1
-│  │  ├─ URL: https://github.com/facebook/watchman
-│  │  ├─ VendorName: Wez Furlong
-│  │  └─ VendorUrl: https://facebook.github.io/watchman/docs/bser.html
-│  ├─ doctrine@2.1.0
-│  │  ├─ URL: https://github.com/eslint/doctrine.git
-│  │  └─ VendorUrl: https://github.com/eslint/doctrine
-│  ├─ doctrine@3.0.0
-│  │  ├─ URL: https://github.com/eslint/doctrine.git
-│  │  └─ VendorUrl: https://github.com/eslint/doctrine
-│  ├─ ejs@3.1.9
-│  │  ├─ URL: git://github.com/mde/ejs.git
-│  │  ├─ VendorName: Matthew Eernisse
-│  │  └─ VendorUrl: https://github.com/mde/ejs
-│  ├─ eslint-visitor-keys@1.3.0
-│  │  ├─ URL: https://github.com/eslint/eslint-visitor-keys.git
-│  │  ├─ VendorName: Toru Nagashima
-│  │  └─ VendorUrl: https://github.com/eslint/eslint-visitor-keys#readme
-│  ├─ eslint-visitor-keys@2.1.0
-│  │  ├─ URL: https://github.com/eslint/eslint-visitor-keys.git
-│  │  ├─ VendorName: Toru Nagashima
-│  │  └─ VendorUrl: https://github.com/eslint/eslint-visitor-keys#readme
-│  ├─ eslint-visitor-keys@3.4.1
-│  │  ├─ URL: https://github.com/eslint/eslint-visitor-keys.git
-│  │  ├─ VendorName: Toru Nagashima
-│  │  └─ VendorUrl: https://github.com/eslint/eslint-visitor-keys#readme
-│  ├─ fb-watchman@2.0.2
-│  │  ├─ URL: git@github.com:facebook/watchman.git
-│  │  ├─ VendorName: Wez Furlong
-│  │  └─ VendorUrl: https://facebook.github.io/watchman/
-│  ├─ filelist@1.0.4
-│  │  ├─ URL: git://github.com/mde/filelist.git
-│  │  ├─ VendorName: Matthew Eernisse
-│  │  └─ VendorUrl: https://github.com/mde/filelist
-│  ├─ human-signals@2.1.0
-│  │  ├─ URL: https://github.com/ehmicky/human-signals.git
-│  │  ├─ VendorName: ehmicky
-│  │  └─ VendorUrl: https://git.io/JeluP
-│  ├─ human-signals@4.3.1
-│  │  ├─ URL: https://github.com/ehmicky/human-signals.git
-│  │  ├─ VendorName: ehmicky
-│  │  └─ VendorUrl: https://www.github.com/ehmicky/human-signals
-│  ├─ jake@10.8.7
-│  │  ├─ URL: git://github.com/jakejs/jake.git
-│  │  ├─ VendorName: Matthew Eernisse
-│  │  └─ VendorUrl: http://fleegix.org
-│  ├─ lazy-universal-dotenv@4.0.0
-│  │  ├─ URL: git+https://github.com/storybooks/lazy-universal-dotenv.git
-│  │  ├─ VendorName: Storybook Team
-│  │  └─ VendorUrl: https://github.com/storybooks/lazy-universal-dotenv#readme
-│  ├─ puppeteer-core@2.1.1
-│  │  ├─ URL: https://github.com/puppeteer/puppeteer.git
-│  │  └─ VendorName: The Chromium Authors
-│  ├─ rxjs@7.8.1
-│  │  ├─ URL: https://github.com/reactivex/rxjs.git
-│  │  ├─ VendorName: Ben Lesh
-│  │  └─ VendorUrl: https://rxjs.dev/
-│  ├─ spdx-correct@3.2.0
-│  │  └─ URL: https://github.com/jslicense/spdx-correct.js.git
-│  ├─ typescript@5.1.3
-│  │  ├─ URL: https://github.com/Microsoft/TypeScript.git
-│  │  ├─ VendorName: Microsoft Corp.
-│  │  └─ VendorUrl: https://www.typescriptlang.org/
-│  ├─ validate-npm-package-license@3.0.4
-│  │  ├─ URL: https://github.com/kemitchell/validate-npm-package-license.js.git
-│  │  ├─ VendorName: Kyle E. Mitchell
-│  │  └─ VendorUrl: https://kemitchell.com
-│  ├─ walker@1.0.8
-│  │  ├─ URL: https://github.com/daaku/nodejs-walker
-│  │  ├─ VendorName: Naitik Shah
-│  │  └─ VendorUrl: https://github.com/daaku/nodejs-walker
-│  └─ xml-name-validator@4.0.0
-│     ├─ URL: https://github.com/jsdom/xml-name-validator.git
-│     ├─ VendorName: Domenic Denicola
-│     └─ VendorUrl: https://domenic.me/
-├─ BSD-2-Clause
-│  ├─ @base2/pretty-print-object@1.0.1
-│  │  ├─ URL: https://github.com/Chris-Baker/pretty-print-object
-│  │  └─ VendorName: Chris Baker
-│  ├─ @typescript-eslint/parser@5.59.11
-│  │  └─ URL: https://github.com/typescript-eslint/typescript-eslint.git
-│  ├─ @typescript-eslint/typescript-estree@5.59.11
-│  │  └─ URL: https://github.com/typescript-eslint/typescript-eslint.git
-│  ├─ @yarnpkg/esbuild-plugin-pnp@3.0.0-rc.15
-│  │  └─ URL: ssh://git@github.com/yarnpkg/berry.git
-│  ├─ css-select@4.3.0
-│  │  ├─ URL: git://github.com/fb55/css-select.git
-│  │  └─ VendorName: Felix Boehm
-│  ├─ css-what@6.1.0
-│  │  ├─ URL: https://github.com/fb55/css-what
-│  │  ├─ VendorName: Felix Böhm
-│  │  └─ VendorUrl: http://feedic.com
-│  ├─ domelementtype@2.3.0
-│  │  ├─ URL: git://github.com/fb55/domelementtype.git
-│  │  └─ VendorName: Felix Boehm
-│  ├─ domhandler@4.3.1
-│  │  ├─ URL: git://github.com/fb55/domhandler.git
-│  │  └─ VendorName: Felix Boehm
-│  ├─ domutils@2.8.0
-│  │  ├─ URL: git://github.com/fb55/domutils.git
-│  │  └─ VendorName: Felix Boehm
-│  ├─ dotenv-expand@10.0.0
-│  │  ├─ URL: https://github.com/motdotla/dotenv-expand
-│  │  └─ VendorName: motdotla
-│  ├─ dotenv@16.1.4
-│  │  └─ URL: git://github.com/motdotla/dotenv.git
-│  ├─ entities@2.2.0
-│  │  ├─ URL: git://github.com/fb55/entities.git
-│  │  └─ VendorName: Felix Boehm
-│  ├─ entities@4.5.0
-│  │  ├─ URL: git://github.com/fb55/entities.git
-│  │  └─ VendorName: Felix Boehm
-│  ├─ escodegen@2.0.0
-│  │  ├─ URL: http://github.com/estools/escodegen.git
-│  │  └─ VendorUrl: http://github.com/estools/escodegen
-│  ├─ eslint-scope@5.1.1
-│  │  ├─ URL: https://github.com/eslint/eslint-scope.git
-│  │  └─ VendorUrl: http://github.com/eslint/eslint-scope
-│  ├─ eslint-scope@7.2.0
-│  │  ├─ URL: https://github.com/eslint/eslint-scope.git
-│  │  └─ VendorUrl: http://github.com/eslint/eslint-scope
-│  ├─ espree@9.5.2
-│  │  ├─ URL: https://github.com/eslint/espree.git
-│  │  ├─ VendorName: Nicholas C. Zakas
-│  │  └─ VendorUrl: https://github.com/eslint/espree
-│  ├─ esprima@4.0.1
-│  │  ├─ URL: https://github.com/jquery/esprima.git
-│  │  ├─ VendorName: Ariya Hidayat
-│  │  └─ VendorUrl: http://esprima.org/
-│  ├─ esrecurse@4.3.0
-│  │  ├─ URL: https://github.com/estools/esrecurse.git
-│  │  └─ VendorUrl: https://github.com/estools/esrecurse
-│  ├─ estraverse@4.3.0
-│  │  ├─ URL: http://github.com/estools/estraverse.git
-│  │  └─ VendorUrl: https://github.com/estools/estraverse
-│  ├─ estraverse@5.3.0
-│  │  ├─ URL: http://github.com/estools/estraverse.git
-│  │  └─ VendorUrl: https://github.com/estools/estraverse
-│  ├─ esutils@2.0.3
-│  │  ├─ URL: http://github.com/estools/esutils.git
-│  │  └─ VendorUrl: https://github.com/estools/esutils
-│  ├─ extract-zip@1.7.0
-│  │  ├─ URL: https://github.com/maxogden/extract-zip.git
-│  │  └─ VendorName: max ogden
-│  ├─ glob-to-regexp@0.4.1
-│  │  ├─ URL: https://github.com/fitzgen/glob-to-regexp.git
-│  │  └─ VendorName: Nick Fitzgerald
-│  ├─ normalize-package-data@2.5.0
-│  │  ├─ URL: git://github.com/npm/normalize-package-data.git
-│  │  └─ VendorName: Meryn Stol
-│  ├─ nth-check@2.1.1
-│  │  ├─ URL: https://github.com/fb55/nth-check
-│  │  ├─ VendorName: Felix Boehm
-│  │  └─ VendorUrl: https://github.com/fb55/nth-check
-│  ├─ regjsparser@0.9.1
-│  │  ├─ URL: git@github.com:jviereck/regjsparser.git
-│  │  ├─ VendorName: 'Julian Viereck'
-│  │  └─ VendorUrl: https://github.com/jviereck/regjsparser
-│  ├─ terser@5.18.0
-│  │  ├─ URL: https://github.com/terser/terser
-│  │  ├─ VendorName: Mihai Bazon
-│  │  └─ VendorUrl: https://terser.org/
-│  ├─ uglify-js@3.17.4
-│  │  ├─ URL: https://github.com/mishoo/UglifyJS.git
-│  │  ├─ VendorName: Mihai Bazon
-│  │  └─ VendorUrl: http://lisperator.net/
-│  ├─ uri-js@4.4.1
-│  │  ├─ URL: http://github.com/garycourt/uri-js
-│  │  ├─ VendorName: Gary Court
-│  │  └─ VendorUrl: https://github.com/garycourt/uri-js
-│  ├─ webidl-conversions@3.0.1
-│  │  ├─ URL: https://github.com/jsdom/webidl-conversions.git
-│  │  ├─ VendorName: Domenic Denicola
-│  │  └─ VendorUrl: https://domenic.me/
-│  └─ webidl-conversions@7.0.0
-│     ├─ URL: https://github.com/jsdom/webidl-conversions.git
-│     ├─ VendorName: Domenic Denicola
-│     └─ VendorUrl: https://domenic.me/
-├─ BSD-3-Clause
-│  ├─ @humanwhocodes/object-schema@1.2.1
-│  │  ├─ URL: git+https://github.com/humanwhocodes/object-schema.git
-│  │  ├─ VendorName: Nicholas C. Zakas
-│  │  └─ VendorUrl: https://github.com/humanwhocodes/object-schema#readme
-│  ├─ @sinonjs/commons@1.8.6
-│  │  ├─ URL: git+https://github.com/sinonjs/commons.git
-│  │  └─ VendorUrl: https://github.com/sinonjs/commons#readme
-│  ├─ @sinonjs/commons@3.0.0
-│  │  ├─ URL: git+https://github.com/sinonjs/commons.git
-│  │  └─ VendorUrl: https://github.com/sinonjs/commons#readme
-│  ├─ @sinonjs/fake-timers@10.2.0
-│  │  ├─ URL: https://github.com/sinonjs/fake-timers.git
-│  │  ├─ VendorName: Christian Johansen
-│  │  └─ VendorUrl: https://github.com/sinonjs/fake-timers
-│  ├─ @sinonjs/fake-timers@9.1.2
-│  │  ├─ URL: https://github.com/sinonjs/fake-timers.git
-│  │  ├─ VendorName: Christian Johansen
-│  │  └─ VendorUrl: https://github.com/sinonjs/fake-timers
-│  ├─ @xtuc/ieee754@1.2.0
-│  │  ├─ URL: git://github.com/feross/ieee754.git
-│  │  ├─ VendorName: Feross Aboukhadijeh
-│  │  └─ VendorUrl: http://feross.org
-│  ├─ abab@2.0.6
-│  │  ├─ URL: git+https://github.com/jsdom/abab.git
-│  │  ├─ VendorName: Jeff Carpenter
-│  │  └─ VendorUrl: https://github.com/jsdom/abab#readme
-│  ├─ babel-plugin-istanbul@6.1.1
-│  │  ├─ URL: git+https://github.com/istanbuljs/babel-plugin-istanbul.git
-│  │  ├─ VendorName: Thai Pangsakulyanont @dtinth
-│  │  └─ VendorUrl: https://github.com/istanbuljs/babel-plugin-istanbul#readme
-│  ├─ esquery@1.5.0
-│  │  ├─ URL: https://github.com/estools/esquery.git
-│  │  ├─ VendorName: Joel Feenstra
-│  │  └─ VendorUrl: https://github.com/estools/esquery/
-│  ├─ hoist-non-react-statics@3.3.2
-│  │  ├─ URL: git://github.com/mridgway/hoist-non-react-statics.git
-│  │  └─ VendorName: Michael Ridgway
-│  ├─ ieee754@1.2.1
-│  │  ├─ URL: git://github.com/feross/ieee754.git
-│  │  ├─ VendorName: Feross Aboukhadijeh
-│  │  └─ VendorUrl: https://feross.org
-│  ├─ istanbul-lib-coverage@3.2.0
-│  │  ├─ URL: git+ssh://git@github.com/istanbuljs/istanbuljs.git
-│  │  ├─ VendorName: Krishnan Anantheswaran
-│  │  └─ VendorUrl: https://istanbul.js.org/
-│  ├─ istanbul-lib-instrument@5.2.1
-│  │  ├─ URL: git+ssh://git@github.com/istanbuljs/istanbuljs.git
-│  │  ├─ VendorName: Krishnan Anantheswaran
-│  │  └─ VendorUrl: https://istanbul.js.org/
-│  ├─ istanbul-lib-report@3.0.0
-│  │  ├─ URL: git+ssh://git@github.com/istanbuljs/istanbuljs.git
-│  │  ├─ VendorName: Krishnan Anantheswaran
-│  │  └─ VendorUrl: https://istanbul.js.org/
-│  ├─ istanbul-lib-source-maps@4.0.1
-│  │  ├─ URL: git+ssh://git@github.com/istanbuljs/istanbuljs.git
-│  │  ├─ VendorName: Krishnan Anantheswaran
-│  │  └─ VendorUrl: https://istanbul.js.org/
-│  ├─ istanbul-reports@3.1.5
-│  │  ├─ URL: git+ssh://git@github.com/istanbuljs/istanbuljs.git
-│  │  ├─ VendorName: Krishnan Anantheswaran
-│  │  └─ VendorUrl: https://istanbul.js.org/
-│  ├─ makeerror@1.0.12
-│  │  ├─ URL: https://github.com/daaku/nodejs-makeerror
-│  │  └─ VendorName: Naitik Shah
-│  ├─ qs@6.11.0
-│  │  ├─ URL: https://github.com/ljharb/qs.git
-│  │  └─ VendorUrl: https://github.com/ljharb/qs
-│  ├─ qs@6.11.2
-│  │  ├─ URL: https://github.com/ljharb/qs.git
-│  │  └─ VendorUrl: https://github.com/ljharb/qs
-│  ├─ react-transition-group@4.4.5
-│  │  ├─ URL: https://github.com/reactjs/react-transition-group.git
-│  │  └─ VendorUrl: https://github.com/reactjs/react-transition-group#readme
-│  ├─ serialize-javascript@6.0.1
-│  │  ├─ URL: git+https://github.com/yahoo/serialize-javascript.git
-│  │  ├─ VendorName: Eric Ferraiuolo
-│  │  └─ VendorUrl: https://github.com/yahoo/serialize-javascript
-│  ├─ shelljs@0.8.5
-│  │  ├─ URL: git://github.com/shelljs/shelljs.git
-│  │  └─ VendorUrl: http://github.com/shelljs/shelljs
-│  ├─ source-map-js@1.0.2
-│  │  ├─ URL: https://github.com/7rulnik/source-map-js.git
-│  │  ├─ VendorName: Valentin 7rulnik Semirulnik
-│  │  └─ VendorUrl: https://github.com/7rulnik/source-map-js
-│  ├─ source-map@0.5.7
-│  │  ├─ URL: http://github.com/mozilla/source-map.git
-│  │  ├─ VendorName: Nick Fitzgerald
-│  │  └─ VendorUrl: https://github.com/mozilla/source-map
-│  ├─ source-map@0.6.1
-│  │  ├─ URL: http://github.com/mozilla/source-map.git
-│  │  ├─ VendorName: Nick Fitzgerald
-│  │  └─ VendorUrl: https://github.com/mozilla/source-map
-│  ├─ source-map@0.7.4
-│  │  ├─ URL: http://github.com/mozilla/source-map.git
-│  │  ├─ VendorName: Nick Fitzgerald
-│  │  └─ VendorUrl: https://github.com/mozilla/source-map
-│  ├─ sprintf-js@1.0.3
-│  │  ├─ URL: https://github.com/alexei/sprintf.js.git
-│  │  ├─ VendorName: Alexandru Marasteanu
-│  │  └─ VendorUrl: http://alexei.ro/
-│  ├─ synchronous-promise@2.0.17
-│  │  ├─ URL: git+https://github.com/fluffynuts/synchronous-promise.git
-│  │  ├─ VendorName: Davyd McColl
-│  │  └─ VendorUrl: https://github.com/fluffynuts
-│  ├─ tmpl@1.0.5
-│  │  ├─ URL: https://github.com/daaku/nodejs-tmpl
-│  │  ├─ VendorName: Naitik Shah
-│  │  └─ VendorUrl: https://github.com/daaku/nodejs-tmpl
-│  └─ tough-cookie@4.1.3
-│     ├─ URL: git://github.com/salesforce/tough-cookie.git
-│     ├─ VendorName: Jeremy Stashewsky
-│     └─ VendorUrl: https://github.com/salesforce/tough-cookie
-├─ CC-BY-3.0
-│  └─ spdx-exceptions@2.3.0
-│     ├─ URL: https://github.com/kemitchell/spdx-exceptions.json.git
-│     └─ VendorName: The Linux Foundation
-├─ CC-BY-4.0
-│  └─ caniuse-lite@1.0.30001503
-│     ├─ URL: https://github.com/browserslist/caniuse-lite.git
-│     ├─ VendorName: Ben Briggs
-│     └─ VendorUrl: http://beneb.info
-├─ CC0-1.0
-│  ├─ mdn-data@2.0.14
-│  │  ├─ URL: https://github.com/mdn/data.git
-│  │  ├─ VendorName: Mozilla Developer Network
-│  │  └─ VendorUrl: https://developer.mozilla.org/
-│  ├─ spdx-license-ids@3.0.13
-│  │  ├─ URL: https://github.com/jslicense/spdx-license-ids.git
-│  │  ├─ VendorName: Shinnosuke Watanabe
-│  │  └─ VendorUrl: https://github.com/shinnn
-│  └─ string-hash@1.1.3
-│     ├─ URL: git://github.com/darkskyapp/string-hash.git
-│     └─ VendorName: The Dark Sky Company
-├─ ISC
-│  ├─ @istanbuljs/load-nyc-config@1.1.0
-│  │  ├─ URL: git+https://github.com/istanbuljs/load-nyc-config.git
-│  │  └─ VendorUrl: https://github.com/istanbuljs/load-nyc-config#readme
-│  ├─ @trysound/sax@0.2.0
-│  │  ├─ URL: git://github.com/svg/sax.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me/
-│  ├─ ansi-align@3.0.1
-│  │  ├─ URL: git+https://github.com/nexdrew/ansi-align.git
-│  │  ├─ VendorName: nexdrew
-│  │  └─ VendorUrl: https://github.com/nexdrew/ansi-align#readme
-│  ├─ anymatch@3.1.3
-│  │  ├─ URL: https://github.com/micromatch/anymatch
-│  │  ├─ VendorName: Elan Shanker
-│  │  └─ VendorUrl: https://github.com/micromatch/anymatch
-│  ├─ aproba@2.0.0
-│  │  ├─ URL: https://github.com/iarna/aproba
-│  │  ├─ VendorName: Rebecca Turner
-│  │  └─ VendorUrl: https://github.com/iarna/aproba
-│  ├─ are-we-there-yet@2.0.0
-│  │  ├─ URL: https://github.com/npm/are-we-there-yet.git
-│  │  ├─ VendorName: GitHub Inc.
-│  │  └─ VendorUrl: https://github.com/npm/are-we-there-yet
-│  ├─ boolbase@1.0.0
-│  │  ├─ URL: https://github.com/fb55/boolbase
-│  │  ├─ VendorName: Felix Boehm
-│  │  └─ VendorUrl: https://github.com/fb55/boolbase
-│  ├─ c8@7.14.0
-│  │  ├─ URL: git@github.com:bcoe/c8.git
-│  │  └─ VendorName: Ben Coe
-│  ├─ chownr@1.1.4
-│  │  ├─ URL: git://github.com/isaacs/chownr.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me/
-│  ├─ chownr@2.0.0
-│  │  ├─ URL: git://github.com/isaacs/chownr.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me/
-│  ├─ cliui@7.0.4
-│  │  ├─ URL: https://github.com/yargs/cliui.git
-│  │  └─ VendorName: Ben Coe
-│  ├─ cliui@8.0.1
-│  │  ├─ URL: https://github.com/yargs/cliui.git
-│  │  └─ VendorName: Ben Coe
-│  ├─ color-support@1.1.3
-│  │  ├─ URL: git+https://github.com/isaacs/color-support.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me/
-│  ├─ common-path-prefix@3.0.0
-│  │  ├─ URL: git+https://github.com/novemberborn/common-path-prefix.git
-│  │  ├─ VendorName: Mark Wubben
-│  │  └─ VendorUrl: https://github.com/novemberborn/common-path-prefix#readme
-│  ├─ concat-with-sourcemaps@1.1.0
-│  │  ├─ URL: git://github.com/floridoo/concat-with-sourcemaps.git
-│  │  ├─ VendorName: Florian Reiterer
-│  │  └─ VendorUrl: http://github.com/floridoo/concat-with-sourcemaps
-│  ├─ console-control-strings@1.1.0
-│  │  ├─ URL: https://github.com/iarna/console-control-strings
-│  │  ├─ VendorName: Rebecca Turner
-│  │  └─ VendorUrl: http://re-becca.org/
-│  ├─ css-declaration-sorter@6.4.0
-│  │  ├─ URL: https://github.com/Siilwyn/css-declaration-sorter.git
-│  │  ├─ VendorName: Selwyn
-│  │  └─ VendorUrl: https://selwyn.cc/
-│  ├─ electron-to-chromium@1.4.431
-│  │  ├─ URL: https://github.com/kilian/electron-to-chromium/
-│  │  └─ VendorName: Kilian Valkhof
-│  ├─ eslint-plugin-promise@6.1.1
-│  │  ├─ URL: https://github.com/eslint-community/eslint-plugin-promise
-│  │  ├─ VendorName: jden
-│  │  └─ VendorUrl: https://github.com/eslint-community/eslint-plugin-promise
-│  ├─ fastq@1.15.0
-│  │  ├─ URL: git+https://github.com/mcollina/fastq.git
-│  │  ├─ VendorName: Matteo Collina
-│  │  └─ VendorUrl: https://github.com/mcollina/fastq#readme
-│  ├─ flatted@3.2.7
-│  │  ├─ URL: git+https://github.com/WebReflection/flatted.git
-│  │  ├─ VendorName: Andrea Giammarchi
-│  │  └─ VendorUrl: https://github.com/WebReflection/flatted#readme
-│  ├─ foreground-child@2.0.0
-│  │  ├─ URL: git+https://github.com/tapjs/foreground-child.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: https://github.com/tapjs/foreground-child#readme
-│  ├─ fs-minipass@2.1.0
-│  │  ├─ URL: git+https://github.com/npm/fs-minipass.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: https://github.com/npm/fs-minipass#readme
-│  ├─ fs.realpath@1.0.0
-│  │  ├─ URL: git+https://github.com/isaacs/fs.realpath.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me/
-│  ├─ gauge@3.0.2
-│  │  ├─ URL: https://github.com/iarna/gauge
-│  │  ├─ VendorName: Rebecca Turner
-│  │  └─ VendorUrl: https://github.com/npm/gauge
-│  ├─ get-caller-file@2.0.5
-│  │  ├─ URL: git+https://github.com/stefanpenner/get-caller-file.git
-│  │  ├─ VendorName: Stefan Penner
-│  │  └─ VendorUrl: https://github.com/stefanpenner/get-caller-file#readme
-│  ├─ github-slugger@1.5.0
-│  │  ├─ URL: https://github.com/Flet/github-slugger.git
-│  │  ├─ VendorName: Dan Flettre
-│  │  └─ VendorUrl: https://github.com/Flet/github-slugger
-│  ├─ glob-parent@5.1.2
-│  │  ├─ URL: https://github.com/gulpjs/glob-parent.git
-│  │  ├─ VendorName: Gulp Team
-│  │  └─ VendorUrl: https://gulpjs.com/
-│  ├─ glob-parent@6.0.2
-│  │  ├─ URL: https://github.com/gulpjs/glob-parent.git
-│  │  ├─ VendorName: Gulp Team
-│  │  └─ VendorUrl: https://gulpjs.com/
-│  ├─ glob@7.2.3
-│  │  ├─ URL: git://github.com/isaacs/node-glob.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me/
-│  ├─ glob@8.1.0
-│  │  ├─ URL: git://github.com/isaacs/node-glob.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me/
-│  ├─ graceful-fs@4.2.11
-│  │  └─ URL: https://github.com/isaacs/node-graceful-fs
-│  ├─ has-unicode@2.0.1
-│  │  ├─ URL: https://github.com/iarna/has-unicode
-│  │  ├─ VendorName: Rebecca Turner
-│  │  └─ VendorUrl: https://github.com/iarna/has-unicode
-│  ├─ hosted-git-info@2.8.9
-│  │  ├─ URL: git+https://github.com/npm/hosted-git-info.git
-│  │  ├─ VendorName: Rebecca Turner
-│  │  └─ VendorUrl: https://github.com/npm/hosted-git-info
-│  ├─ icss-replace-symbols@1.1.0
-│  │  ├─ URL: git+https://github.com/css-modules/icss-replace-symbols.git
-│  │  ├─ VendorName: Glen Maddern
-│  │  └─ VendorUrl: https://github.com/css-modules/icss-replace-symbols#readme
-│  ├─ icss-utils@5.1.0
-│  │  ├─ URL: git+https://github.com/css-modules/icss-utils.git
-│  │  ├─ VendorName: Glen Maddern
-│  │  └─ VendorUrl: https://github.com/css-modules/icss-utils#readme
-│  ├─ inflight@1.0.6
-│  │  ├─ URL: https://github.com/npm/inflight.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: https://github.com/isaacs/inflight
-│  ├─ inherits@2.0.4
-│  │  └─ URL: git://github.com/isaacs/inherits
-│  ├─ isexe@2.0.0
-│  │  ├─ URL: git+https://github.com/isaacs/isexe.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: https://github.com/isaacs/isexe#readme
-│  ├─ lru-cache@5.1.1
-│  │  ├─ URL: git://github.com/isaacs/node-lru-cache.git
-│  │  └─ VendorName: Isaac Z. Schlueter
-│  ├─ lru-cache@6.0.0
-│  │  ├─ URL: git://github.com/isaacs/node-lru-cache.git
-│  │  └─ VendorName: Isaac Z. Schlueter
-│  ├─ minimatch@3.1.2
-│  │  ├─ URL: git://github.com/isaacs/minimatch.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me
-│  ├─ minimatch@5.1.6
-│  │  ├─ URL: git://github.com/isaacs/minimatch.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me
-│  ├─ minipass@3.3.6
-│  │  ├─ URL: git+https://github.com/isaacs/minipass.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me/
-│  ├─ minipass@5.0.0
-│  │  ├─ URL: git+https://github.com/isaacs/minipass.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me/
-│  ├─ npmlog@5.0.1
-│  │  ├─ URL: https://github.com/npm/npmlog.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me/
-│  ├─ objectorarray@1.0.5
-│  │  ├─ URL: git+https://github.com/ZhouHansen/objectnotnull.git
-│  │  ├─ VendorName: zhouhancheng
-│  │  └─ VendorUrl: https://github.com/ZhouHansen/objectnotnull#readme
-│  ├─ once@1.4.0
-│  │  ├─ URL: git://github.com/isaacs/once
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me/
-│  ├─ picocolors@1.0.0
-│  │  ├─ URL: https://github.com/alexeyraspopov/picocolors.git
-│  │  └─ VendorName: Alexey Raspopov
-│  ├─ postcss-modules-extract-imports@3.0.0
-│  │  ├─ URL: https://github.com/css-modules/postcss-modules-extract-imports.git
-│  │  ├─ VendorName: Glen Maddern
-│  │  └─ VendorUrl: https://github.com/css-modules/postcss-modules-extract-imports
-│  ├─ postcss-modules-scope@3.0.0
-│  │  ├─ URL: https://github.com/css-modules/postcss-modules-scope.git
-│  │  ├─ VendorName: Glen Maddern
-│  │  └─ VendorUrl: https://github.com/css-modules/postcss-modules-scope
-│  ├─ postcss-modules-values@4.0.0
-│  │  ├─ URL: git+https://github.com/css-modules/postcss-modules-values.git
-│  │  ├─ VendorName: Glen Maddern
-│  │  └─ VendorUrl: https://github.com/css-modules/postcss-modules-values#readme
-│  ├─ rimraf@2.6.3
-│  │  ├─ URL: git://github.com/isaacs/rimraf.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me/
-│  ├─ rimraf@2.7.1
-│  │  ├─ URL: git://github.com/isaacs/rimraf.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me/
-│  ├─ rimraf@3.0.2
-│  │  ├─ URL: git://github.com/isaacs/rimraf.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me/
-│  ├─ safe-identifier@0.4.2
-│  │  ├─ URL: https://github.com/eemeli/safe-identifier.git
-│  │  ├─ VendorName: Eemeli Aro
-│  │  └─ VendorUrl: https://github.com/eemeli/safe-identifier#readme
-│  ├─ saxes@6.0.0
-│  │  ├─ URL: https://github.com/lddubeau/saxes.git
-│  │  └─ VendorName: Louis-Dominique Dubeau
-│  ├─ semver@5.7.1
-│  │  └─ URL: https://github.com/npm/node-semver
-│  ├─ semver@6.3.0
-│  │  └─ URL: https://github.com/npm/node-semver
-│  ├─ semver@7.0.0
-│  │  └─ URL: https://github.com/npm/node-semver
-│  ├─ semver@7.5.1
-│  │  ├─ URL: https://github.com/npm/node-semver.git
-│  │  └─ VendorName: GitHub Inc.
-│  ├─ set-blocking@2.0.0
-│  │  ├─ URL: git+https://github.com/yargs/set-blocking.git
-│  │  ├─ VendorName: Ben Coe
-│  │  └─ VendorUrl: https://github.com/yargs/set-blocking#readme
-│  ├─ setprototypeof@1.2.0
-│  │  ├─ URL: https://github.com/wesleytodd/setprototypeof.git
-│  │  ├─ VendorName: Wes Todd
-│  │  └─ VendorUrl: https://github.com/wesleytodd/setprototypeof
-│  ├─ signal-exit@3.0.7
-│  │  ├─ URL: https://github.com/tapjs/signal-exit.git
-│  │  ├─ VendorName: Ben Coe
-│  │  └─ VendorUrl: https://github.com/tapjs/signal-exit
-│  ├─ tar@6.1.15
-│  │  ├─ URL: https://github.com/isaacs/node-tar.git
-│  │  └─ VendorName: GitHub Inc.
-│  ├─ test-exclude@6.0.0
-│  │  ├─ URL: git+https://github.com/istanbuljs/test-exclude.git
-│  │  ├─ VendorName: Ben Coe
-│  │  └─ VendorUrl: https://istanbul.js.org/
-│  ├─ v8-to-istanbul@9.1.0
-│  │  ├─ URL: https://github.com/istanbuljs/v8-to-istanbul.git
-│  │  └─ VendorName: Ben Coe
-│  ├─ which@2.0.2
-│  │  ├─ URL: git://github.com/isaacs/node-which.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me
-│  ├─ wide-align@1.1.5
-│  │  ├─ URL: https://github.com/iarna/wide-align
-│  │  ├─ VendorName: Rebecca Turner
-│  │  └─ VendorUrl: http://re-becca.org/
-│  ├─ wrappy@1.0.2
-│  │  ├─ URL: https://github.com/npm/wrappy
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: https://github.com/npm/wrappy
-│  ├─ write-file-atomic@2.4.3
-│  │  ├─ URL: git@github.com:iarna/write-file-atomic.git
-│  │  ├─ VendorName: Rebecca Turner
-│  │  └─ VendorUrl: https://github.com/iarna/write-file-atomic
-│  ├─ write-file-atomic@3.0.3
-│  │  ├─ URL: git://github.com/npm/write-file-atomic.git
-│  │  ├─ VendorName: Rebecca Turner
-│  │  └─ VendorUrl: https://github.com/npm/write-file-atomic
-│  ├─ write-file-atomic@4.0.2
-│  │  ├─ URL: https://github.com/npm/write-file-atomic.git
-│  │  ├─ VendorName: GitHub Inc.
-│  │  └─ VendorUrl: https://github.com/npm/write-file-atomic
-│  ├─ y18n@5.0.8
-│  │  ├─ URL: https://github.com/yargs/y18n.git
-│  │  ├─ VendorName: Ben Coe
-│  │  └─ VendorUrl: https://github.com/yargs/y18n
-│  ├─ yallist@3.1.1
-│  │  ├─ URL: git+https://github.com/isaacs/yallist.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me/
-│  ├─ yallist@4.0.0
-│  │  ├─ URL: git+https://github.com/isaacs/yallist.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me/
-│  ├─ yaml@1.10.2
-│  │  ├─ URL: https://github.com/eemeli/yaml.git
-│  │  ├─ VendorName: Eemeli Aro
-│  │  └─ VendorUrl: https://eemeli.org/yaml/v1/
-│  ├─ yaml@2.3.1
-│  │  ├─ URL: https://github.com/eemeli/yaml.git
-│  │  ├─ VendorName: Eemeli Aro
-│  │  └─ VendorUrl: https://eemeli.org/yaml/
-│  ├─ yargs-parser@20.2.9
-│  │  ├─ URL: https://github.com/yargs/yargs-parser.git
-│  │  └─ VendorName: Ben Coe
-│  └─ yargs-parser@21.1.1
-│     ├─ URL: https://github.com/yargs/yargs-parser.git
-│     └─ VendorName: Ben Coe
-├─ MIT
-│  ├─ @aw-web-design/x-default-browser@1.4.88
-│  │  ├─ URL: https://github.com/The-Code-Monkey/TechStack.git
-│  │  └─ VendorUrl: https://github.com/The-Code-Monkey/TechStack/blob/dev/packages/x-default-browser/README.md
-│  ├─ @babel/code-frame@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-code-frame
-│  ├─ @babel/compat-data@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/team
-│  ├─ @babel/core@7.21.8
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-core
-│  ├─ @babel/core@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-core
-│  ├─ @babel/generator@7.21.9
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-generator
-│  ├─ @babel/generator@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-generator
-│  ├─ @babel/helper-annotate-as-pure@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helper-annotate-as-pure
-│  ├─ @babel/helper-builder-binary-assignment-operator-visitor@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helper-builder-binary-assignment-operator-visitor
-│  ├─ @babel/helper-compilation-targets@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/team
-│  ├─ @babel/helper-create-class-features-plugin@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/team
-│  ├─ @babel/helper-create-regexp-features-plugin@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/team
-│  ├─ @babel/helper-define-polyfill-provider@0.3.3
-│  │  └─ URL: https://github.com/babel/babel-polyfills.git
-│  ├─ @babel/helper-define-polyfill-provider@0.4.0
-│  │  └─ URL: https://github.com/babel/babel-polyfills.git
-│  ├─ @babel/helper-environment-visitor@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helper-environment-visitor
-│  ├─ @babel/helper-function-name@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helper-function-name
-│  ├─ @babel/helper-hoist-variables@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helper-hoist-variables
-│  ├─ @babel/helper-member-expression-to-functions@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helper-member-expression-to-functions
-│  ├─ @babel/helper-module-imports@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helper-module-imports
-│  ├─ @babel/helper-module-transforms@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helper-module-transforms
-│  ├─ @babel/helper-optimise-call-expression@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helper-optimise-call-expression
-│  ├─ @babel/helper-plugin-utils@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helper-plugin-utils
-│  ├─ @babel/helper-remap-async-to-generator@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helper-remap-async-to-generator
-│  ├─ @babel/helper-replace-supers@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helper-replace-supers
-│  ├─ @babel/helper-simple-access@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helper-simple-access
-│  ├─ @babel/helper-skip-transparent-expression-wrappers@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/team
-│  ├─ @babel/helper-split-export-declaration@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helper-split-export-declaration
-│  ├─ @babel/helper-string-parser@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helper-string-parser
-│  ├─ @babel/helper-validator-identifier@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/team
-│  ├─ @babel/helper-validator-option@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/team
-│  ├─ @babel/helper-wrap-function@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helper-wrap-function
-│  ├─ @babel/helpers@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helpers
-│  ├─ @babel/highlight@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-highlight
-│  ├─ @babel/parser@7.21.9
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-parser
-│  ├─ @babel/parser@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-parser
-│  ├─ @babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-bugfix-safari-id-destructuring-collision-in-function-expression
-│  ├─ @babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining
-│  ├─ @babel/plugin-proposal-async-generator-functions@7.20.7
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-proposal-async-generator-functions
-│  ├─ @babel/plugin-proposal-class-properties@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-proposal-class-properties
-│  ├─ @babel/plugin-proposal-class-static-block@7.21.0
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-proposal-class-static-block
-│  ├─ @babel/plugin-proposal-dynamic-import@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/team
-│  ├─ @babel/plugin-proposal-export-namespace-from@7.18.9
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-proposal-export-namespace-from
-│  ├─ @babel/plugin-proposal-json-strings@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-proposal-json-strings
-│  ├─ @babel/plugin-proposal-logical-assignment-operators@7.20.7
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-proposal-logical-assignment-operators
-│  ├─ @babel/plugin-proposal-nullish-coalescing-operator@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-proposal-nullish-coalescing-operator
-│  ├─ @babel/plugin-proposal-numeric-separator@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-proposal-numeric-separator
-│  ├─ @babel/plugin-proposal-object-rest-spread@7.20.7
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-proposal-object-rest-spread
-│  ├─ @babel/plugin-proposal-optional-catch-binding@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-proposal-optional-catch-binding
-│  ├─ @babel/plugin-proposal-optional-chaining@7.21.0
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-proposal-optional-chaining
-│  ├─ @babel/plugin-proposal-private-methods@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-proposal-private-methods
-│  ├─ @babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2
-│  │  ├─ URL: https://github.com/babel/babel-plugin-proposal-private-property-in-object.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-proposal-private-property-in-object
-│  ├─ @babel/plugin-proposal-private-property-in-object@7.21.11
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-proposal-private-property-in-object
-│  ├─ @babel/plugin-proposal-unicode-property-regex@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-proposal-unicode-property-regex
-│  ├─ @babel/plugin-syntax-async-generators@7.8.4
-│  │  └─ URL: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-async-generators
-│  ├─ @babel/plugin-syntax-bigint@7.8.3
-│  │  └─ URL: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-bigint
-│  ├─ @babel/plugin-syntax-class-properties@7.12.13
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-syntax-class-properties
-│  ├─ @babel/plugin-syntax-class-static-block@7.14.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-syntax-class-static-block
-│  ├─ @babel/plugin-syntax-dynamic-import@7.8.3
-│  │  └─ URL: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-dynamic-import
-│  ├─ @babel/plugin-syntax-export-namespace-from@7.8.3
-│  │  └─ URL: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-export-namespace-from
-│  ├─ @babel/plugin-syntax-flow@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-syntax-flow
-│  ├─ @babel/plugin-syntax-import-assertions@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/team
-│  ├─ @babel/plugin-syntax-import-attributes@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/team
-│  ├─ @babel/plugin-syntax-import-meta@7.10.4
-│  │  └─ URL: https://github.com/babel/babel.git
-│  ├─ @babel/plugin-syntax-json-strings@7.8.3
-│  │  └─ URL: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-json-strings
-│  ├─ @babel/plugin-syntax-jsx@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-syntax-jsx
-│  ├─ @babel/plugin-syntax-logical-assignment-operators@7.10.4
-│  │  └─ URL: https://github.com/babel/babel.git
-│  ├─ @babel/plugin-syntax-nullish-coalescing-operator@7.8.3
-│  │  └─ URL: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-nullish-coalescing-operator
-│  ├─ @babel/plugin-syntax-numeric-separator@7.10.4
-│  │  └─ URL: https://github.com/babel/babel.git
-│  ├─ @babel/plugin-syntax-object-rest-spread@7.8.3
-│  │  └─ URL: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-object-rest-spread
-│  ├─ @babel/plugin-syntax-optional-catch-binding@7.8.3
-│  │  └─ URL: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-catch-binding
-│  ├─ @babel/plugin-syntax-optional-chaining@7.8.3
-│  │  └─ URL: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-chaining
-│  ├─ @babel/plugin-syntax-private-property-in-object@7.14.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-syntax-private-property-in-object
-│  ├─ @babel/plugin-syntax-top-level-await@7.14.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-syntax-top-level-await
-│  ├─ @babel/plugin-syntax-typescript@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-syntax-typescript
-│  ├─ @babel/plugin-syntax-unicode-sets-regex@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-syntax-unicode-sets-regex
-│  ├─ @babel/plugin-transform-arrow-functions@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-arrow-functions
-│  ├─ @babel/plugin-transform-async-generator-functions@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-async-generator-functions
-│  ├─ @babel/plugin-transform-async-to-generator@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-async-to-generator
-│  ├─ @babel/plugin-transform-block-scoped-functions@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-block-scoped-functions
-│  ├─ @babel/plugin-transform-block-scoping@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-block-scoping
-│  ├─ @babel/plugin-transform-class-properties@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-class-properties
-│  ├─ @babel/plugin-transform-class-static-block@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-class-static-block
-│  ├─ @babel/plugin-transform-classes@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-classes
-│  ├─ @babel/plugin-transform-computed-properties@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-computed-properties
-│  ├─ @babel/plugin-transform-destructuring@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-destructuring
-│  ├─ @babel/plugin-transform-dotall-regex@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-dotall-regex
-│  ├─ @babel/plugin-transform-duplicate-keys@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-duplicate-keys
-│  ├─ @babel/plugin-transform-dynamic-import@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/team
-│  ├─ @babel/plugin-transform-exponentiation-operator@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-exponentiation-operator
-│  ├─ @babel/plugin-transform-export-namespace-from@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-export-namespace-from
-│  ├─ @babel/plugin-transform-flow-strip-types@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-flow-strip-types
-│  ├─ @babel/plugin-transform-for-of@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-for-of
-│  ├─ @babel/plugin-transform-function-name@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-function-name
-│  ├─ @babel/plugin-transform-json-strings@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-json-strings
-│  ├─ @babel/plugin-transform-literals@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-literals
-│  ├─ @babel/plugin-transform-logical-assignment-operators@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-logical-assignment-operators
-│  ├─ @babel/plugin-transform-member-expression-literals@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-member-expression-literals
-│  ├─ @babel/plugin-transform-modules-amd@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-modules-amd
-│  ├─ @babel/plugin-transform-modules-commonjs@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-modules-commonjs
-│  ├─ @babel/plugin-transform-modules-systemjs@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-modules-systemjs
-│  ├─ @babel/plugin-transform-modules-umd@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-modules-umd
-│  ├─ @babel/plugin-transform-named-capturing-groups-regex@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-named-capturing-groups-regex
-│  ├─ @babel/plugin-transform-new-target@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-new-target
-│  ├─ @babel/plugin-transform-nullish-coalescing-operator@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-nullish-coalescing-operator
-│  ├─ @babel/plugin-transform-numeric-separator@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-numeric-separator
-│  ├─ @babel/plugin-transform-object-rest-spread@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-object-rest-spread
-│  ├─ @babel/plugin-transform-object-super@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-object-super
-│  ├─ @babel/plugin-transform-optional-catch-binding@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-optional-catch-binding
-│  ├─ @babel/plugin-transform-optional-chaining@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-optional-chaining
-│  ├─ @babel/plugin-transform-parameters@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-parameters
-│  ├─ @babel/plugin-transform-private-methods@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-private-methods
-│  ├─ @babel/plugin-transform-private-property-in-object@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-private-property-in-object
-│  ├─ @babel/plugin-transform-property-literals@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-property-literals
-│  ├─ @babel/plugin-transform-react-display-name@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-react-display-name
-│  ├─ @babel/plugin-transform-react-jsx-development@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/team
-│  ├─ @babel/plugin-transform-react-jsx@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-react-jsx
-│  ├─ @babel/plugin-transform-react-pure-annotations@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/team
-│  ├─ @babel/plugin-transform-regenerator@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-regenerator
-│  ├─ @babel/plugin-transform-reserved-words@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-reserved-words
-│  ├─ @babel/plugin-transform-shorthand-properties@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-shorthand-properties
-│  ├─ @babel/plugin-transform-spread@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-spread
-│  ├─ @babel/plugin-transform-sticky-regex@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-sticky-regex
-│  ├─ @babel/plugin-transform-template-literals@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-template-literals
-│  ├─ @babel/plugin-transform-typeof-symbol@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-typeof-symbol
-│  ├─ @babel/plugin-transform-typescript@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-typescript
-│  ├─ @babel/plugin-transform-unicode-escapes@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-unicode-escapes
-│  ├─ @babel/plugin-transform-unicode-property-regex@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-unicode-property-regex
-│  ├─ @babel/plugin-transform-unicode-regex@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-unicode-regex
-│  ├─ @babel/plugin-transform-unicode-sets-regex@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-unicode-sets-regex
-│  ├─ @babel/preset-env@7.21.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-preset-env
-│  ├─ @babel/preset-env@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-preset-env
-│  ├─ @babel/preset-flow@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-preset-flow
-│  ├─ @babel/preset-modules@0.1.5
-│  │  └─ URL: https://github.com/babel/preset-modules.git
-│  ├─ @babel/preset-react@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-preset-react
-│  ├─ @babel/preset-typescript@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-preset-typescript
-│  ├─ @babel/register@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-register
-│  ├─ @babel/regjsgen@0.8.0
-│  │  ├─ URL: https://github.com/bnjmnt4n/regjsgen.git
-│  │  ├─ VendorName: Benjamin Tan
-│  │  └─ VendorUrl: https://github.com/bnjmnt4n/regjsgen
-│  ├─ @babel/runtime@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-runtime
-│  ├─ @babel/template@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-template
-│  ├─ @babel/traverse@7.21.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-traverse
-│  ├─ @babel/traverse@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-traverse
-│  ├─ @babel/types@7.21.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-types
-│  ├─ @babel/types@7.22.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-types
-│  ├─ @bcoe/v8-coverage@0.2.3
-│  │  ├─ URL: git://github.com/demurgos/v8-coverage.git
-│  │  ├─ VendorName: Charles Samborski
-│  │  └─ VendorUrl: https://demurgos.github.io/v8-coverage
-│  ├─ @colors/colors@1.5.0
-│  │  ├─ URL: http://github.com/DABH/colors.js.git
-│  │  ├─ VendorName: DABH
-│  │  └─ VendorUrl: https://github.com/DABH/colors.js
-│  ├─ @date-io/core@2.16.0
-│  │  ├─ URL: https://github.com/dmtrKovalenko/date-io
-│  │  └─ VendorName: Dmitriy Kovalenko
-│  ├─ @date-io/date-fns@2.16.0
-│  │  ├─ URL: https://github.com/dmtrKovalenko/date-io
-│  │  └─ VendorName: Dmitriy Kovalenko
-│  ├─ @date-io/dayjs@2.16.0
-│  │  ├─ URL: https://github.com/dmtrKovalenko/date-io
-│  │  └─ VendorName: Dmitriy Kovalenko
-│  ├─ @date-io/luxon@2.16.1
-│  │  ├─ URL: https://github.com/dmtrKovalenko/date-io
-│  │  └─ VendorName: Dmitriy Kovalenko
-│  ├─ @date-io/moment@2.16.1
-│  │  ├─ URL: https://github.com/dmtrKovalenko/date-io
-│  │  └─ VendorName: Dmitriy Kovalenko
-│  ├─ @discoveryjs/json-ext@0.5.7
-│  │  ├─ URL: https://github.com/discoveryjs/json-ext.git
-│  │  ├─ VendorName: Roman Dvornov
-│  │  └─ VendorUrl: https://github.com/lahmatiy
-│  ├─ @emotion/babel-plugin@11.11.0
-│  │  ├─ URL: https://github.com/emotion-js/emotion/tree/main/packages/babel-plugin
-│  │  ├─ VendorName: Kye Hohenberger
-│  │  └─ VendorUrl: https://emotion.sh/
-│  ├─ @emotion/cache@11.11.0
-│  │  └─ URL: https://github.com/emotion-js/emotion/tree/main/packages/cache
-│  ├─ @emotion/hash@0.9.1
-│  │  └─ URL: https://github.com/emotion-js/emotion/tree/main/packages/hash
-│  ├─ @emotion/is-prop-valid@1.2.1
-│  │  └─ URL: https://github.com/emotion-js/emotion/tree/main/packages/is-prop-valid
-│  ├─ @emotion/memoize@0.8.1
-│  │  └─ URL: https://github.com/emotion-js/emotion/tree/main/packages/memoize
-│  ├─ @emotion/react@11.11.1
-│  │  ├─ URL: https://github.com/emotion-js/emotion/tree/main/packages/react
-│  │  └─ VendorName: Emotion Contributors
-│  ├─ @emotion/serialize@1.1.2
-│  │  └─ URL: https://github.com/emotion-js/emotion/tree/main/packages/serialize
-│  ├─ @emotion/sheet@1.2.2
-│  │  └─ URL: https://github.com/emotion-js/emotion/tree/main/packages/sheet
-│  ├─ @emotion/styled@11.11.0
-│  │  └─ URL: https://github.com/emotion-js/emotion/tree/main/packages/styled
-│  ├─ @emotion/unitless@0.8.1
-│  │  └─ URL: https://github.com/emotion-js/emotion/tree/main/packages/unitless
-│  ├─ @emotion/use-insertion-effect-with-fallbacks@1.0.1
-│  │  └─ URL: https://github.com/emotion-js/emotion/tree/main/packages/use-insertion-effect-with-fallbacks
-│  ├─ @emotion/utils@1.2.1
-│  │  └─ URL: https://github.com/emotion-js/emotion/tree/main/packages/utils
-│  ├─ @emotion/weak-memoize@0.3.1
-│  │  └─ URL: https://github.com/emotion-js/emotion/tree/main/packages/weak-memoize
-│  ├─ @esbuild/darwin-arm64@0.17.19
-│  │  └─ URL: https://github.com/evanw/esbuild
-│  ├─ @eslint-community/eslint-utils@4.4.0
-│  │  ├─ URL: https://github.com/eslint-community/eslint-utils
-│  │  ├─ VendorName: Toru Nagashima
-│  │  └─ VendorUrl: https://github.com/eslint-community/eslint-utils#readme
-│  ├─ @eslint-community/regexpp@4.5.1
-│  │  ├─ URL: https://github.com/eslint-community/regexpp
-│  │  ├─ VendorName: Toru Nagashima
-│  │  └─ VendorUrl: https://github.com/eslint-community/regexpp#readme
-│  ├─ @eslint/eslintrc@2.0.3
-│  │  ├─ URL: https://github.com/eslint/eslintrc.git
-│  │  ├─ VendorName: Nicholas C. Zakas
-│  │  └─ VendorUrl: https://github.com/eslint/eslintrc#readme
-│  ├─ @eslint/js@8.37.0
-│  │  ├─ URL: https://github.com/eslint/eslint.git
-│  │  └─ VendorUrl: https://eslint.org/
-│  ├─ @fal-works/esbuild-plugin-global-externals@2.1.2
-│  │  ├─ URL: https://github.com/fal-works/esbuild-plugin-global-externals#readme
-│  │  ├─ VendorName: FAL
-│  │  └─ VendorUrl: https://github.com/fal-works/esbuild-plugin-global-externals#readme
-│  ├─ @istanbuljs/schema@0.1.3
-│  │  ├─ URL: git+https://github.com/istanbuljs/schema.git
-│  │  ├─ VendorName: Corey Farrell
-│  │  └─ VendorUrl: https://github.com/istanbuljs/schema#readme
-│  ├─ @jest/console@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jest/core@28.1.3
-│  │  ├─ URL: https://github.com/facebook/jest.git
-│  │  └─ VendorUrl: https://jestjs.io/
-│  ├─ @jest/environment@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jest/environment@29.5.0
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jest/expect-utils@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jest/expect@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jest/fake-timers@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jest/fake-timers@29.5.0
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jest/globals@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jest/reporters@28.1.3
-│  │  ├─ URL: https://github.com/facebook/jest.git
-│  │  └─ VendorUrl: https://jestjs.io/
-│  ├─ @jest/schemas@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jest/schemas@29.4.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jest/source-map@28.1.2
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jest/test-result@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jest/test-sequencer@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jest/transform@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jest/transform@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jest/transform@29.5.0
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jest/types@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jest/types@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jest/types@29.5.0
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jridgewell/gen-mapping@0.3.3
-│  │  ├─ URL: https://github.com/jridgewell/gen-mapping
-│  │  └─ VendorName: Justin Ridgewell
-│  ├─ @jridgewell/resolve-uri@3.1.0
-│  │  ├─ URL: https://github.com/jridgewell/resolve-uri
-│  │  └─ VendorName: Justin Ridgewell
-│  ├─ @jridgewell/set-array@1.1.2
-│  │  ├─ URL: https://github.com/jridgewell/set-array
-│  │  └─ VendorName: Justin Ridgewell
-│  ├─ @jridgewell/source-map@0.3.3
-│  │  ├─ URL: https://github.com/jridgewell/source-map
-│  │  └─ VendorName: Justin Ridgewell
-│  ├─ @jridgewell/sourcemap-codec@1.4.14
-│  │  ├─ URL: git+https://github.com/jridgewell/sourcemap-codec.git
-│  │  └─ VendorName: Rich Harris
-│  ├─ @jridgewell/sourcemap-codec@1.4.15
-│  │  ├─ URL: git+https://github.com/jridgewell/sourcemap-codec.git
-│  │  └─ VendorName: Rich Harris
-│  ├─ @jridgewell/trace-mapping@0.3.18
-│  │  ├─ URL: git+https://github.com/jridgewell/trace-mapping.git
-│  │  └─ VendorName: Justin Ridgewell
-│  ├─ @mdx-js/react@2.3.0
-│  │  ├─ URL: https://github.com/mdx-js/mdx
-│  │  ├─ VendorName: John Otander
-│  │  └─ VendorUrl: https://mdxjs.com/
-│  ├─ @mui/base@5.0.0-beta.4
-│  │  ├─ URL: https://github.com/mui/material-ui.git
-│  │  ├─ VendorName: MUI Team
-│  │  └─ VendorUrl: https://mui.com/base/getting-started/overview/
-│  ├─ @mui/core-downloads-tracker@5.13.4
-│  │  ├─ URL: https://github.com/mui/material-ui.git
-│  │  ├─ VendorName: MUI Team
-│  │  └─ VendorUrl: https://mui.com/
-│  ├─ @mui/icons-material@5.11.16
-│  │  ├─ URL: https://github.com/mui/material-ui.git
-│  │  ├─ VendorName: MUI Team
-│  │  └─ VendorUrl: https://mui.com/material-ui/material-icons/
-│  ├─ @mui/material@5.13.5
-│  │  ├─ URL: https://github.com/mui/material-ui.git
-│  │  ├─ VendorName: MUI Team
-│  │  └─ VendorUrl: https://mui.com/material-ui/getting-started/overview/
-│  ├─ @mui/private-theming@5.13.1
-│  │  ├─ URL: https://github.com/mui/material-ui.git
-│  │  ├─ VendorName: MUI Team
-│  │  └─ VendorUrl: https://mui.com/
-│  ├─ @mui/styled-engine@5.13.2
-│  │  ├─ URL: https://github.com/mui/material-ui.git
-│  │  ├─ VendorName: MUI Team
-│  │  └─ VendorUrl: https://mui.com/material-ui/guides/styled-engine/
-│  ├─ @mui/system@5.13.5
-│  │  ├─ URL: https://github.com/mui/material-ui.git
-│  │  ├─ VendorName: MUI Team
-│  │  └─ VendorUrl: https://mui.com/system/getting-started/overview/
-│  ├─ @mui/types@7.2.4
-│  │  ├─ URL: https://github.com/mui/material-ui.git
-│  │  ├─ VendorName: MUI Team
-│  │  └─ VendorUrl: https://github.com/mui/material-ui/tree/master/packages/mui-types
-│  ├─ @mui/utils@5.13.1
-│  │  ├─ URL: https://github.com/mui/material-ui.git
-│  │  ├─ VendorName: MUI Team
-│  │  └─ VendorUrl: https://github.com/mui/material-ui/tree/master/packages/mui-utils
-│  ├─ @mui/x-data-grid@5.17.26
-│  │  ├─ URL: https://github.com/mui/mui-x.git
-│  │  ├─ VendorName: MUI Team
-│  │  └─ VendorUrl: https://mui.com/x/react-data-grid/
-│  ├─ @mui/x-date-pickers@5.0.20
-│  │  ├─ URL: https://github.com/mui/mui-x.git
-│  │  ├─ VendorName: MUI Team
-│  │  └─ VendorUrl: https://mui.com/x/react-date-pickers/getting-started/
-│  ├─ @ndelangen/get-tarball@3.0.9
-│  │  ├─ URL: git+https://github.com/ndelangen/download-tarball.git
-│  │  ├─ VendorName: David Björklund
-│  │  └─ VendorUrl: https://github.com/ndelangen/download-tarball#readme
-│  ├─ @nodelib/fs.scandir@2.1.5
-│  │  └─ URL: https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.scandir
-│  ├─ @nodelib/fs.stat@2.0.5
-│  │  └─ URL: https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.stat
-│  ├─ @nodelib/fs.walk@1.2.8
-│  │  └─ URL: https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.walk
-│  ├─ @pmmmwh/react-refresh-webpack-plugin@0.5.10
-│  │  ├─ URL: git+https://github.com/pmmmwh/react-refresh-webpack-plugin.git
-│  │  ├─ VendorName: Michael Mok
-│  │  └─ VendorUrl: https://github.com/pmmmwh/react-refresh-webpack-plugin#readme
-│  ├─ @popperjs/core@2.11.8
-│  │  ├─ URL: https://github.com/popperjs/popper-core.git
-│  │  └─ VendorName: Federico Zivolo
-│  ├─ @rollup/plugin-commonjs@25.0.1
-│  │  ├─ URL: https://github.com/rollup/plugins.git
-│  │  ├─ VendorName: Rich Harris
-│  │  └─ VendorUrl: https://github.com/rollup/plugins/tree/master/packages/commonjs/#readme
-│  ├─ @rollup/plugin-image@3.0.2
-│  │  ├─ URL: https://github.com/rollup/plugins.git
-│  │  ├─ VendorName: Rich Harris
-│  │  └─ VendorUrl: https://github.com/rollup/plugins/tree/master/packages/image/#readme
-│  ├─ @rollup/plugin-node-resolve@15.1.0
-│  │  ├─ URL: https://github.com/rollup/plugins.git
-│  │  ├─ VendorName: Rich Harris
-│  │  └─ VendorUrl: https://github.com/rollup/plugins/tree/master/packages/node-resolve/#readme
-│  ├─ @rollup/plugin-typescript@11.1.1
-│  │  ├─ URL: https://github.com/rollup/plugins.git
-│  │  ├─ VendorName: Oskar Segersvärd
-│  │  └─ VendorUrl: https://github.com/rollup/plugins/tree/master/packages/typescript/#readme
-│  ├─ @rollup/pluginutils@5.0.2
-│  │  ├─ URL: https://github.com/rollup/plugins.git
-│  │  ├─ VendorName: Rich Harris
-│  │  └─ VendorUrl: https://github.com/rollup/plugins/tree/master/packages/pluginutils#readme
-│  ├─ @sinclair/typebox@0.24.51
-│  │  ├─ URL: https://github.com/sinclairzx81/typebox
-│  │  └─ VendorName: sinclairzx81
-│  ├─ @sinclair/typebox@0.25.24
-│  │  ├─ URL: https://github.com/sinclairzx81/typebox
-│  │  └─ VendorName: sinclairzx81
-│  ├─ @storybook/addon-actions@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/addons/actions
-│  ├─ @storybook/addon-backgrounds@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  ├─ VendorName: jbaxleyiii
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/addons/backgrounds
-│  ├─ @storybook/addon-controls@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/addons/controls
-│  ├─ @storybook/addon-docs@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/addons/docs
-│  ├─ @storybook/addon-essentials@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/addons/essentials
-│  ├─ @storybook/addon-highlight@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  ├─ VendorName: winkerVSbecks
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/addons/highlight
-│  ├─ @storybook/addon-links@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/addons/links
-│  ├─ @storybook/addon-measure@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  ├─ VendorName: winkerVSbecks
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/addons/measure
-│  ├─ @storybook/addon-outline@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  ├─ VendorName: winkerVSbecks
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/addons/outline
-│  ├─ @storybook/addon-toolbars@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/addons/toolbars
-│  ├─ @storybook/addon-viewport@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/addons/viewport
-│  ├─ @storybook/addons@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/lib/addons
-│  ├─ @storybook/api@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/lib/api
-│  ├─ @storybook/blocks@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/ui/blocks
-│  ├─ @storybook/builder-manager@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/lib/builder-manager
-│  ├─ @storybook/builder-webpack5@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/lib/builder-webpack5
-│  ├─ @storybook/channel-postmessage@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/lib/channel-postmessage
-│  ├─ @storybook/channel-websocket@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/lib/channel-websocket
-│  ├─ @storybook/channels@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/lib/channels
-│  ├─ @storybook/cli@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  ├─ VendorName: Storybook Team
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/lib/cli
-│  ├─ @storybook/client-api@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/lib/client-api
-│  ├─ @storybook/client-logger@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/lib/client-logger
-│  ├─ @storybook/codemod@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/lib/codemod
-│  ├─ @storybook/components@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/ui/components
-│  ├─ @storybook/core-client@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/lib/core-client
-│  ├─ @storybook/core-common@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/lib/core-common
-│  ├─ @storybook/core-events@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/lib/core-events
-│  ├─ @storybook/core-server@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/lib/core-server
-│  ├─ @storybook/core-webpack@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/lib/core-webpack
-│  ├─ @storybook/csf-plugin@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/lib/csf-plugin
-│  ├─ @storybook/csf-tools@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/lib/csf-tools
-│  ├─ @storybook/csf@0.1.1
-│  │  ├─ URL: https://github.com/ComponentDriven/csf.git
-│  │  └─ VendorUrl: https://github.com/ComponentDriven/csf
-│  ├─ @storybook/docs-mdx@0.1.0
-│  │  ├─ URL: https://github.com/storybookjs/docs-mdx
-│  │  └─ VendorName: Michael Shilman
-│  ├─ @storybook/docs-tools@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/lib/docs-tools
-│  ├─ @storybook/global@5.0.0
-│  │  ├─ URL: git://github.com/storybookjs/global.git
-│  │  ├─ VendorName: Norbert
-│  │  └─ VendorUrl: https://github.com/storybookjs/global
-│  ├─ @storybook/manager-api@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/lib/manager-api
-│  ├─ @storybook/manager@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/ui/manager
-│  ├─ @storybook/mdx2-csf@1.1.0
-│  │  ├─ URL: https://github.com/storybookjs/csf-mdx2
-│  │  └─ VendorName: Michael Shilman
-│  ├─ @storybook/node-logger@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/lib/node-logger
-│  ├─ @storybook/postinstall@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/lib/postinstall
-│  ├─ @storybook/preset-react-webpack@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/presets/react-webpack
-│  ├─ @storybook/preset-scss@1.0.3
-│  │  ├─ URL: https://github.com/storybookjs/presets.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/presets/tree/master/packages/preset-scss
-│  ├─ @storybook/preview-api@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/lib/preview-api
-│  ├─ @storybook/preview@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/lib/preview
-│  ├─ @storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0
-│  │  ├─ URL: https://github.com/hipstersmoothie/react-docgen-typescript-plugin.git
-│  │  └─ VendorName: Andrew Lisowski
-│  ├─ @storybook/react-dom-shim@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/lib/react-dom-shim
-│  ├─ @storybook/react-webpack5@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/frameworks/react-webpack5
-│  ├─ @storybook/react@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/renderers/react
-│  ├─ @storybook/router@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/lib/router
-│  ├─ @storybook/store@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/lib/store
-│  ├─ @storybook/telemetry@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/lib/telemetry
-│  ├─ @storybook/theming@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/lib/theming
-│  ├─ @storybook/types@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/lib/types
-│  ├─ @testing-library/dom@9.3.1
-│  │  ├─ URL: https://github.com/testing-library/dom-testing-library
-│  │  ├─ VendorName: Kent C. Dodds
-│  │  └─ VendorUrl: https://github.com/testing-library/dom-testing-library#readme
-│  ├─ @testing-library/react@14.0.0
-│  │  ├─ URL: https://github.com/testing-library/react-testing-library
-│  │  ├─ VendorName: Kent C. Dodds
-│  │  └─ VendorUrl: https://github.com/testing-library/react-testing-library#readme
-│  ├─ @tootallnate/once@2.0.0
-│  │  ├─ URL: git://github.com/TooTallNate/once.git
-│  │  ├─ VendorName: Nathan Rajlich
-│  │  └─ VendorUrl: http://n8.io/
-│  ├─ @types/aria-query@5.0.1
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/aria-query
-│  ├─ @types/autosuggest-highlight@3.2.0
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/autosuggest-highlight
-│  ├─ @types/babel__core@7.20.1
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/babel__core
-│  ├─ @types/babel__generator@7.6.4
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/babel__generator
-│  ├─ @types/babel__template@7.4.1
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/babel__template
-│  ├─ @types/babel__traverse@7.20.1
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/babel__traverse
-│  ├─ @types/body-parser@1.19.2
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/body-parser
-│  ├─ @types/connect@3.4.35
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/connect
-│  ├─ @types/detect-port@1.3.3
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/detect-port
-│  ├─ @types/doctrine@0.0.3
-│  │  ├─ URL: https://www.github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorName: rictic
-│  ├─ @types/ejs@3.1.2
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/ejs
-│  ├─ @types/escodegen@0.0.6
-│  │  ├─ URL: https://www.github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorName: Simon de Lang
-│  ├─ @types/eslint-scope@3.7.4
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/eslint-scope
-│  ├─ @types/eslint@8.40.2
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/eslint
-│  ├─ @types/estree@0.0.51
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/estree
-│  ├─ @types/estree@1.0.1
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/estree
-│  ├─ @types/express-serve-static-core@4.17.35
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/express-serve-static-core
-│  ├─ @types/express@4.17.17
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/express
-│  ├─ @types/find-cache-dir@3.2.1
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/find-cache-dir
-│  ├─ @types/glob@8.1.0
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/glob
-│  ├─ @types/graceful-fs@4.1.6
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/graceful-fs
-│  ├─ @types/html-minifier-terser@6.1.0
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/html-minifier-terser
-│  ├─ @types/istanbul-lib-coverage@2.0.4
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/istanbul-lib-coverage
-│  ├─ @types/istanbul-lib-report@3.0.0
-│  │  └─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  ├─ @types/istanbul-reports@3.0.1
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/istanbul-reports
-│  ├─ @types/jest@28.1.8
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/jest
-│  ├─ @types/jsdom@20.0.1
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/jsdom
-│  ├─ @types/json-schema@7.0.12
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/json-schema
-│  ├─ @types/json5@0.0.29
-│  │  ├─ URL: https://www.github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorName: Jason Swearingen
-│  ├─ @types/lodash@4.14.195
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/lodash
-│  ├─ @types/mdx@2.0.5
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/mdx
-│  ├─ @types/mime-types@2.1.1
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/mime-types
-│  ├─ @types/mime@1.3.2
-│  │  └─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  ├─ @types/mime@3.0.1
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/mime
-│  ├─ @types/minimatch@5.1.2
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/minimatch
-│  ├─ @types/node-fetch@2.6.4
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node-fetch
-│  ├─ @types/node@16.18.36
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node
-│  ├─ @types/node@20.3.1
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node
-│  ├─ @types/normalize-package-data@2.4.1
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/normalize-package-data
-│  ├─ @types/npmlog@4.1.4
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/npmlog
-│  ├─ @types/parse-json@4.0.0
-│  │  └─ URL: https://www.github.com/DefinitelyTyped/DefinitelyTyped.git
-│  ├─ @types/prettier@2.7.3
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/prettier
-│  ├─ @types/pretty-hrtime@1.0.1
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/pretty-hrtime
-│  ├─ @types/prop-types@15.7.5
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/prop-types
-│  ├─ @types/qs@6.9.7
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/qs
-│  ├─ @types/range-parser@1.2.4
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/range-parser
-│  ├─ @types/react-dom@18.2.5
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-dom
-│  ├─ @types/react-is@18.2.0
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-is
-│  ├─ @types/react-slick@0.23.10
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-slick
-│  ├─ @types/react-transition-group@4.4.6
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-transition-group
-│  ├─ @types/react@18.2.12
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react
-│  ├─ @types/resolve@1.20.2
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/resolve
-│  ├─ @types/scheduler@0.16.3
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/scheduler
-│  ├─ @types/semver@7.5.0
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/semver
-│  ├─ @types/send@0.17.1
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/send
-│  ├─ @types/serve-static@1.15.1
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/serve-static
-│  ├─ @types/stack-utils@2.0.1
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/stack-utils
-│  ├─ @types/tough-cookie@4.0.2
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/tough-cookie
-│  ├─ @types/unist@2.0.6
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/unist
-│  ├─ @types/yargs-parser@21.0.0
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/yargs-parser
-│  ├─ @types/yargs@16.0.5
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/yargs
-│  ├─ @types/yargs@17.0.24
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/yargs
-│  ├─ @typescript-eslint/eslint-plugin@5.59.11
-│  │  └─ URL: https://github.com/typescript-eslint/typescript-eslint.git
-│  ├─ @typescript-eslint/scope-manager@5.59.11
-│  │  └─ URL: https://github.com/typescript-eslint/typescript-eslint.git
-│  ├─ @typescript-eslint/type-utils@5.59.11
-│  │  └─ URL: https://github.com/typescript-eslint/typescript-eslint.git
-│  ├─ @typescript-eslint/types@5.59.11
-│  │  └─ URL: https://github.com/typescript-eslint/typescript-eslint.git
-│  ├─ @typescript-eslint/utils@5.59.11
-│  │  └─ URL: https://github.com/typescript-eslint/typescript-eslint.git
-│  ├─ @typescript-eslint/visitor-keys@5.59.11
-│  │  └─ URL: https://github.com/typescript-eslint/typescript-eslint.git
-│  ├─ @webassemblyjs/ast@1.11.6
-│  │  ├─ URL: https://github.com/xtuc/webassemblyjs.git
-│  │  └─ VendorName: Sven Sauleau
-│  ├─ @webassemblyjs/floating-point-hex-parser@1.11.6
-│  │  ├─ URL: https://github.com/xtuc/webassemblyjs.git
-│  │  └─ VendorName: Mauro Bringolf
-│  ├─ @webassemblyjs/helper-api-error@1.11.6
-│  │  ├─ URL: https://github.com/xtuc/webassemblyjs.git
-│  │  └─ VendorName: Sven Sauleau
-│  ├─ @webassemblyjs/helper-buffer@1.11.6
-│  │  ├─ URL: https://github.com/xtuc/webassemblyjs.git
-│  │  └─ VendorName: Sven Sauleau
-│  ├─ @webassemblyjs/helper-numbers@1.11.6
-│  │  ├─ URL: https://github.com/xtuc/webassemblyjs.git
-│  │  └─ VendorName: Sven Sauleau
-│  ├─ @webassemblyjs/helper-wasm-bytecode@1.11.6
-│  │  ├─ URL: https://github.com/xtuc/webassemblyjs.git
-│  │  └─ VendorName: Sven Sauleau
-│  ├─ @webassemblyjs/helper-wasm-section@1.11.6
-│  │  ├─ URL: https://github.com/xtuc/webassemblyjs.git
-│  │  └─ VendorName: Sven Sauleau
-│  ├─ @webassemblyjs/ieee754@1.11.6
-│  │  └─ URL: https://github.com/xtuc/webassemblyjs.git
-│  ├─ @webassemblyjs/utf8@1.11.6
-│  │  ├─ URL: https://github.com/xtuc/webassemblyjs.git
-│  │  └─ VendorName: Sven Sauleau
-│  ├─ @webassemblyjs/wasm-edit@1.11.6
-│  │  ├─ URL: https://github.com/xtuc/webassemblyjs.git
-│  │  └─ VendorName: Sven Sauleau
-│  ├─ @webassemblyjs/wasm-gen@1.11.6
-│  │  ├─ URL: https://github.com/xtuc/webassemblyjs.git
-│  │  └─ VendorName: Sven Sauleau
-│  ├─ @webassemblyjs/wasm-opt@1.11.6
-│  │  ├─ URL: https://github.com/xtuc/webassemblyjs.git
-│  │  └─ VendorName: Sven Sauleau
-│  ├─ @webassemblyjs/wasm-parser@1.11.6
-│  │  ├─ URL: https://github.com/xtuc/webassemblyjs.git
-│  │  └─ VendorName: Sven Sauleau
-│  ├─ @webassemblyjs/wast-printer@1.11.6
-│  │  ├─ URL: https://github.com/xtuc/webassemblyjs.git
-│  │  └─ VendorName: Sven Sauleau
-│  ├─ accepts@1.3.8
-│  │  └─ URL: https://github.com/jshttp/accepts.git
-│  ├─ acorn-globals@7.0.1
-│  │  ├─ URL: https://github.com/ForbesLindesay/acorn-globals.git
-│  │  └─ VendorName: ForbesLindesay
-│  ├─ acorn-import-assertions@1.9.0
-│  │  ├─ URL: https://github.com/xtuc/acorn-import-assertions
-│  │  └─ VendorName: Sven Sauleau
-│  ├─ acorn-jsx@5.3.2
-│  │  ├─ URL: https://github.com/acornjs/acorn-jsx
-│  │  └─ VendorUrl: https://github.com/acornjs/acorn-jsx
-│  ├─ acorn-walk@7.2.0
-│  │  ├─ URL: https://github.com/acornjs/acorn.git
-│  │  └─ VendorUrl: https://github.com/acornjs/acorn
-│  ├─ acorn-walk@8.2.0
-│  │  ├─ URL: https://github.com/acornjs/acorn.git
-│  │  └─ VendorUrl: https://github.com/acornjs/acorn
-│  ├─ acorn@7.4.1
-│  │  ├─ URL: https://github.com/acornjs/acorn.git
-│  │  └─ VendorUrl: https://github.com/acornjs/acorn
-│  ├─ acorn@8.8.2
-│  │  ├─ URL: https://github.com/acornjs/acorn.git
-│  │  └─ VendorUrl: https://github.com/acornjs/acorn
-│  ├─ address@1.2.2
-│  │  ├─ URL: git://github.com/node-modules/address.git
-│  │  └─ VendorName: fengmk2
-│  ├─ agent-base@5.1.1
-│  │  ├─ URL: git://github.com/TooTallNate/node-agent-base.git
-│  │  ├─ VendorName: Nathan Rajlich
-│  │  └─ VendorUrl: http://n8.io/
-│  ├─ agent-base@6.0.2
-│  │  ├─ URL: git://github.com/TooTallNate/node-agent-base.git
-│  │  ├─ VendorName: Nathan Rajlich
-│  │  └─ VendorUrl: http://n8.io/
-│  ├─ aggregate-error@3.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/aggregate-error.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ ajv-formats@2.1.1
-│  │  ├─ URL: git+https://github.com/ajv-validator/ajv-formats.git
-│  │  ├─ VendorName: Evgeny Poberezkin
-│  │  └─ VendorUrl: https://github.com/ajv-validator/ajv-formats#readme
-│  ├─ ajv-keywords@3.5.2
-│  │  ├─ URL: git+https://github.com/epoberezkin/ajv-keywords.git
-│  │  ├─ VendorName: Evgeny Poberezkin
-│  │  └─ VendorUrl: https://github.com/epoberezkin/ajv-keywords#readme
-│  ├─ ajv-keywords@5.1.0
-│  │  ├─ URL: git+https://github.com/epoberezkin/ajv-keywords.git
-│  │  ├─ VendorName: Evgeny Poberezkin
-│  │  └─ VendorUrl: https://github.com/epoberezkin/ajv-keywords#readme
-│  ├─ ajv@6.12.6
-│  │  ├─ URL: https://github.com/ajv-validator/ajv.git
-│  │  ├─ VendorName: Evgeny Poberezkin
-│  │  └─ VendorUrl: https://github.com/ajv-validator/ajv
-│  ├─ ajv@8.12.0
-│  │  ├─ URL: https://github.com/ajv-validator/ajv.git
-│  │  ├─ VendorName: Evgeny Poberezkin
-│  │  └─ VendorUrl: https://ajv.js.org/
-│  ├─ ansi-escapes@4.3.2
-│  │  ├─ URL: https://github.com/sindresorhus/ansi-escapes.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ ansi-regex@5.0.1
-│  │  ├─ URL: https://github.com/chalk/ansi-regex.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ ansi-regex@6.0.1
-│  │  ├─ URL: https://github.com/chalk/ansi-regex.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ ansi-styles@3.2.1
-│  │  ├─ URL: https://github.com/chalk/ansi-styles.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ ansi-styles@4.3.0
-│  │  ├─ URL: https://github.com/chalk/ansi-styles.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ ansi-styles@5.2.0
-│  │  ├─ URL: https://github.com/chalk/ansi-styles.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ ansi-styles@6.2.1
-│  │  ├─ URL: https://github.com/chalk/ansi-styles.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ app-root-dir@1.0.2
-│  │  ├─ URL: https://github.com/philidem/node-app-root-dir.git
-│  │  ├─ VendorName: Phillip Gates-Idem
-│  │  └─ VendorUrl: https://github.com/philidem/node-app-root-dir
-│  ├─ argparse@1.0.10
-│  │  └─ URL: https://github.com/nodeca/argparse.git
-│  ├─ array-buffer-byte-length@1.0.0
-│  │  ├─ URL: git+https://github.com/inspect-js/array-buffer-byte-length.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/array-buffer-byte-length#readme
-│  ├─ array-flatten@1.1.1
-│  │  ├─ URL: git://github.com/blakeembrey/array-flatten.git
-│  │  ├─ VendorName: Blake Embrey
-│  │  └─ VendorUrl: https://github.com/blakeembrey/array-flatten
-│  ├─ array-includes@3.1.6
-│  │  ├─ URL: git://github.com/es-shims/array-includes.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: http://ljharb.codes
-│  ├─ array-union@2.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/array-union.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ array.prototype.flat@1.3.1
-│  │  ├─ URL: git://github.com/es-shims/Array.prototype.flat.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: http://ljharb.codes
-│  ├─ array.prototype.flatmap@1.3.1
-│  │  ├─ URL: git://github.com/es-shims/Array.prototype.flatMap.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: http://ljharb.codes
-│  ├─ array.prototype.tosorted@1.1.1
-│  │  ├─ URL: git+https://github.com/es-shims/Array.prototype.toSorted.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/es-shims/Array.prototype.toSorted#readme
-│  ├─ assert@2.0.0
-│  │  ├─ URL: https://github.com/browserify/commonjs-assert.git
-│  │  └─ VendorUrl: https://github.com/browserify/commonjs-assert
-│  ├─ ast-types@0.14.2
-│  │  ├─ URL: git://github.com/benjamn/ast-types.git
-│  │  ├─ VendorName: Ben Newman
-│  │  └─ VendorUrl: http://github.com/benjamn/ast-types
-│  ├─ ast-types@0.15.2
-│  │  ├─ URL: git://github.com/benjamn/ast-types.git
-│  │  ├─ VendorName: Ben Newman
-│  │  └─ VendorUrl: http://github.com/benjamn/ast-types
-│  ├─ ast-types@0.16.1
-│  │  ├─ URL: git://github.com/benjamn/ast-types.git
-│  │  ├─ VendorName: Ben Newman
-│  │  └─ VendorUrl: http://github.com/benjamn/ast-types
-│  ├─ astral-regex@2.0.0
-│  │  ├─ URL: https://github.com/kevva/astral-regex.git
-│  │  ├─ VendorName: Kevin Mårtensson
-│  │  └─ VendorUrl: github.com/kevva
-│  ├─ async-limiter@1.0.1
-│  │  ├─ URL: https://github.com/strml/async-limiter.git
-│  │  └─ VendorName: Samuel Reed
-│  ├─ async@3.2.4
-│  │  ├─ URL: https://github.com/caolan/async.git
-│  │  ├─ VendorName: Caolan McMahon
-│  │  └─ VendorUrl: https://caolan.github.io/async/
-│  ├─ asynckit@0.4.0
-│  │  ├─ URL: git+https://github.com/alexindigo/asynckit.git
-│  │  ├─ VendorName: Alex Indigo
-│  │  └─ VendorUrl: https://github.com/alexindigo/asynckit#readme
-│  ├─ autosuggest-highlight@3.3.4
-│  │  ├─ URL: https://github.com/moroshko/autosuggest-highlight.git
-│  │  └─ VendorName: Misha Moroshko
-│  ├─ available-typed-arrays@1.0.5
-│  │  ├─ URL: git+https://github.com/inspect-js/available-typed-arrays.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/available-typed-arrays#readme
-│  ├─ babel-core@7.0.0-bridge.0
-│  │  └─ VendorName: Logan Smyth
-│  ├─ babel-jest@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ babel-jest@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ babel-loader@8.3.0
-│  │  ├─ URL: https://github.com/babel/babel-loader.git
-│  │  ├─ VendorName: Luis Couto
-│  │  └─ VendorUrl: https://github.com/babel/babel-loader
-│  ├─ babel-loader@9.1.2
-│  │  ├─ URL: https://github.com/babel/babel-loader.git
-│  │  ├─ VendorName: Luis Couto
-│  │  └─ VendorUrl: https://github.com/babel/babel-loader
-│  ├─ babel-plugin-add-react-displayname@0.0.5
-│  │  ├─ URL: git+https://github.com/opbeat/babel-plugin-add-react-displayname.git
-│  │  ├─ VendorName: Ron Cohen
-│  │  └─ VendorUrl: https://github.com/opbeat/babel-plugin-add-react-displayname#readme
-│  ├─ babel-plugin-jest-hoist@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ babel-plugin-jest-hoist@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ babel-plugin-macros@3.1.0
-│  │  ├─ URL: https://github.com/kentcdodds/babel-plugin-macros
-│  │  ├─ VendorName: Kent C. Dodds
-│  │  └─ VendorUrl: https://github.com/kentcdodds/babel-plugin-macros#readme
-│  ├─ babel-plugin-named-exports-order@0.0.2
-│  │  └─ VendorName: Michael Shilman
-│  ├─ babel-plugin-polyfill-corejs2@0.3.3
-│  │  └─ URL: https://github.com/babel/babel-polyfills.git
-│  ├─ babel-plugin-polyfill-corejs2@0.4.3
-│  │  └─ URL: https://github.com/babel/babel-polyfills.git
-│  ├─ babel-plugin-polyfill-corejs3@0.6.0
-│  │  └─ URL: https://github.com/babel/babel-polyfills.git
-│  ├─ babel-plugin-polyfill-corejs3@0.8.1
-│  │  └─ URL: https://github.com/babel/babel-polyfills.git
-│  ├─ babel-plugin-polyfill-regenerator@0.4.1
-│  │  └─ URL: https://github.com/babel/babel-polyfills.git
-│  ├─ babel-plugin-polyfill-regenerator@0.5.0
-│  │  └─ URL: https://github.com/babel/babel-polyfills.git
-│  ├─ babel-plugin-react-docgen@4.2.1
-│  │  ├─ URL: https://github.com/storybooks/babel-plugin-react-docgen
-│  │  └─ VendorName: Madushan Nishantha
-│  ├─ babel-preset-current-node-syntax@1.0.1
-│  │  ├─ URL: https://github.com/nicolo-ribaudo/babel-preset-current-node-syntax.git
-│  │  ├─ VendorName: Nicolò Ribaudo
-│  │  └─ VendorUrl: https://github.com/nicolo-ribaudo
-│  ├─ babel-preset-jest@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ babel-preset-jest@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ balanced-match@1.0.2
-│  │  ├─ URL: git://github.com/juliangruber/balanced-match.git
-│  │  ├─ VendorName: Julian Gruber
-│  │  └─ VendorUrl: https://github.com/juliangruber/balanced-match
-│  ├─ base64-js@1.5.1
-│  │  ├─ URL: git://github.com/beatgammit/base64-js.git
-│  │  ├─ VendorName: T. Jameson Little
-│  │  └─ VendorUrl: https://github.com/beatgammit/base64-js
-│  ├─ better-opn@2.1.1
-│  │  ├─ URL: https://github.com/ExiaSR/better-opn
-│  │  └─ VendorName: Michael Lin
-│  ├─ big.js@5.2.2
-│  │  ├─ URL: https://github.com/MikeMcl/big.js.git
-│  │  └─ VendorName: Michael Mclaughlin
-│  ├─ binary-extensions@2.2.0
-│  │  ├─ URL: https://github.com/sindresorhus/binary-extensions.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ bl@4.1.0
-│  │  ├─ URL: https://github.com/rvagg/bl.git
-│  │  └─ VendorUrl: https://github.com/rvagg/bl
-│  ├─ body-parser@1.20.1
-│  │  └─ URL: https://github.com/expressjs/body-parser.git
-│  ├─ boxen@5.1.2
-│  │  ├─ URL: https://github.com/sindresorhus/boxen.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ bplist-parser@0.2.0
-│  │  ├─ URL: https://github.com/nearinfinity/node-bplist-parser.git
-│  │  ├─ VendorName: Joe Ferner
-│  │  └─ VendorUrl: https://github.com/nearinfinity/node-bplist-parser
-│  ├─ brace-expansion@1.1.11
-│  │  ├─ URL: git://github.com/juliangruber/brace-expansion.git
-│  │  ├─ VendorName: Julian Gruber
-│  │  └─ VendorUrl: https://github.com/juliangruber/brace-expansion
-│  ├─ brace-expansion@2.0.1
-│  │  ├─ URL: git://github.com/juliangruber/brace-expansion.git
-│  │  ├─ VendorName: Julian Gruber
-│  │  └─ VendorUrl: https://github.com/juliangruber/brace-expansion
-│  ├─ braces@3.0.2
-│  │  ├─ URL: https://github.com/micromatch/braces.git
-│  │  ├─ VendorName: Jon Schlinkert
-│  │  └─ VendorUrl: https://github.com/micromatch/braces
-│  ├─ browser-assert@1.2.1
-│  │  ├─ URL: git://github.com/socialally/browser-assert.git
-│  │  └─ VendorName: muji
-│  ├─ browserify-zlib@0.1.4
-│  │  ├─ URL: git://github.com/devongovett/browserify-zlib.git
-│  │  └─ VendorName: Devon Govett
-│  ├─ browserslist@4.21.8
-│  │  ├─ URL: https://github.com/browserslist/browserslist.git
-│  │  └─ VendorName: Andrey Sitnik
-│  ├─ buffer-crc32@0.2.13
-│  │  ├─ URL: git://github.com/brianloveswords/buffer-crc32.git
-│  │  ├─ VendorName: Brian J. Brennan
-│  │  └─ VendorUrl: https://github.com/brianloveswords/buffer-crc32
-│  ├─ buffer-from@1.1.2
-│  │  └─ URL: https://github.com/LinusU/buffer-from.git
-│  ├─ buffer@5.7.1
-│  │  ├─ URL: git://github.com/feross/buffer.git
-│  │  ├─ VendorName: Feross Aboukhadijeh
-│  │  └─ VendorUrl: https://github.com/feross/buffer
-│  ├─ builtin-modules@3.3.0
-│  │  ├─ URL: https://github.com/sindresorhus/builtin-modules.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ builtins@5.0.1
-│  │  └─ URL: https://github.com/juliangruber/builtins.git
-│  ├─ bytes@3.0.0
-│  │  ├─ URL: https://github.com/visionmedia/bytes.js.git
-│  │  ├─ VendorName: TJ Holowaychuk
-│  │  └─ VendorUrl: http://tjholowaychuk.com
-│  ├─ bytes@3.1.2
-│  │  ├─ URL: https://github.com/visionmedia/bytes.js.git
-│  │  ├─ VendorName: TJ Holowaychuk
-│  │  └─ VendorUrl: http://tjholowaychuk.com
-│  ├─ call-bind@1.0.2
-│  │  ├─ URL: git+https://github.com/ljharb/call-bind.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/ljharb/call-bind#readme
-│  ├─ callsites@3.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/callsites.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ camel-case@4.1.2
-│  │  ├─ URL: git://github.com/blakeembrey/change-case.git
-│  │  ├─ VendorName: Blake Embrey
-│  │  └─ VendorUrl: https://github.com/blakeembrey/change-case/tree/master/packages/camel-case#readme
-│  ├─ camelcase@5.3.1
-│  │  ├─ URL: https://github.com/sindresorhus/camelcase.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ camelcase@6.3.0
-│  │  ├─ URL: https://github.com/sindresorhus/camelcase.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ caniuse-api@3.0.0
-│  │  └─ URL: https://github.com/nyalab/caniuse-api.git
-│  ├─ case-sensitive-paths-webpack-plugin@2.4.0
-│  │  ├─ URL: git+https://github.com/Urthen/case-sensitive-paths-webpack-plugin.git
-│  │  ├─ VendorName: Michael Pratt
-│  │  └─ VendorUrl: https://github.com/Urthen/case-sensitive-paths-webpack-plugin#readme
-│  ├─ chalk@2.4.2
-│  │  └─ URL: https://github.com/chalk/chalk.git
-│  ├─ chalk@4.1.2
-│  │  └─ URL: https://github.com/chalk/chalk.git
-│  ├─ chalk@5.2.0
-│  │  └─ URL: https://github.com/chalk/chalk.git
-│  ├─ char-regex@1.0.2
-│  │  ├─ URL: https://github.com/Richienb/char-regex.git
-│  │  └─ VendorName: Richie Bendall
-│  ├─ chokidar@3.5.3
-│  │  ├─ URL: git+https://github.com/paulmillr/chokidar.git
-│  │  ├─ VendorName: Paul Miller
-│  │  └─ VendorUrl: https://github.com/paulmillr/chokidar
-│  ├─ chrome-trace-event@1.0.3
-│  │  ├─ URL: https://github.com/samccone/chrome-trace-event.git
-│  │  └─ VendorName: Trent Mick, Sam Saccone
-│  ├─ ci-info@3.8.0
-│  │  ├─ URL: https://github.com/watson/ci-info.git
-│  │  ├─ VendorName: Thomas Watson Steen
-│  │  └─ VendorUrl: https://github.com/watson/ci-info
-│  ├─ cjs-module-lexer@1.2.3
-│  │  ├─ URL: git+https://github.com/nodejs/cjs-module-lexer.git
-│  │  ├─ VendorName: Guy Bedford
-│  │  └─ VendorUrl: https://github.com/nodejs/cjs-module-lexer#readme
-│  ├─ classnames@2.3.2
-│  │  ├─ URL: https://github.com/JedWatson/classnames.git
-│  │  └─ VendorName: Jed Watson
-│  ├─ clean-css@5.3.2
-│  │  ├─ URL: https://github.com/clean-css/clean-css.git
-│  │  ├─ VendorName: Jakub Pawlowicz
-│  │  └─ VendorUrl: https://github.com/clean-css/clean-css
-│  ├─ clean-stack@2.2.0
-│  │  ├─ URL: https://github.com/sindresorhus/clean-stack.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ cli-boxes@2.2.1
-│  │  ├─ URL: https://github.com/sindresorhus/cli-boxes.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ cli-cursor@3.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/cli-cursor.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ cli-spinners@2.9.0
-│  │  ├─ URL: https://github.com/sindresorhus/cli-spinners.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ cli-table3@0.6.3
-│  │  ├─ URL: https://github.com/cli-table/cli-table3.git
-│  │  ├─ VendorName: James Talmage
-│  │  └─ VendorUrl: https://github.com/cli-table/cli-table3
-│  ├─ cli-truncate@2.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/cli-truncate.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ cli-truncate@3.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/cli-truncate.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ clone-deep@4.0.1
-│  │  ├─ URL: https://github.com/jonschlinkert/clone-deep.git
-│  │  ├─ VendorName: Jon Schlinkert
-│  │  └─ VendorUrl: https://github.com/jonschlinkert/clone-deep
-│  ├─ clone@1.0.4
-│  │  ├─ URL: git://github.com/pvorb/node-clone.git
-│  │  ├─ VendorName: Paul Vorbach
-│  │  └─ VendorUrl: http://paul.vorba.ch/
-│  ├─ clsx@1.2.1
-│  │  ├─ URL: https://github.com/lukeed/clsx.git
-│  │  ├─ VendorName: Luke Edwards
-│  │  └─ VendorUrl: https://lukeed.com
-│  ├─ co@4.6.0
-│  │  └─ URL: https://github.com/tj/co.git
-│  ├─ collect-v8-coverage@1.0.1
-│  │  └─ URL: https://github.com/SimenB/collect-v8-coverage.git
-│  ├─ color-convert@1.9.3
-│  │  ├─ URL: https://github.com/Qix-/color-convert.git
-│  │  └─ VendorName: Heather Arthur
-│  ├─ color-convert@2.0.1
-│  │  ├─ URL: https://github.com/Qix-/color-convert.git
-│  │  └─ VendorName: Heather Arthur
-│  ├─ color-name@1.1.3
-│  │  ├─ URL: git@github.com:dfcreative/color-name.git
-│  │  ├─ VendorName: DY
-│  │  └─ VendorUrl: https://github.com/dfcreative/color-name
-│  ├─ color-name@1.1.4
-│  │  ├─ URL: git@github.com:colorjs/color-name.git
-│  │  ├─ VendorName: DY
-│  │  └─ VendorUrl: https://github.com/colorjs/color-name
-│  ├─ colord@2.9.3
-│  │  ├─ URL: https://github.com/omgovich/colord.git
-│  │  └─ VendorName: Vlad Shilov
-│  ├─ colorette@2.0.20
-│  │  ├─ URL: https://github.com/jorgebucaran/colorette.git
-│  │  └─ VendorName: Jorge Bucaran
-│  ├─ combined-stream@1.0.8
-│  │  ├─ URL: git://github.com/felixge/node-combined-stream.git
-│  │  ├─ VendorName: Felix Geisendörfer
-│  │  └─ VendorUrl: https://github.com/felixge/node-combined-stream
-│  ├─ commander@10.0.1
-│  │  ├─ URL: https://github.com/tj/commander.js.git
-│  │  └─ VendorName: TJ Holowaychuk
-│  ├─ commander@2.20.3
-│  │  ├─ URL: https://github.com/tj/commander.js.git
-│  │  └─ VendorName: TJ Holowaychuk
-│  ├─ commander@6.2.1
-│  │  ├─ URL: https://github.com/tj/commander.js.git
-│  │  └─ VendorName: TJ Holowaychuk
-│  ├─ commander@7.2.0
-│  │  ├─ URL: https://github.com/tj/commander.js.git
-│  │  └─ VendorName: TJ Holowaychuk
-│  ├─ commander@8.3.0
-│  │  ├─ URL: https://github.com/tj/commander.js.git
-│  │  └─ VendorName: TJ Holowaychuk
-│  ├─ commondir@1.0.1
-│  │  ├─ URL: http://github.com/substack/node-commondir.git
-│  │  ├─ VendorName: James Halliday
-│  │  └─ VendorUrl: http://substack.net
-│  ├─ compressible@2.0.18
-│  │  └─ URL: https://github.com/jshttp/compressible.git
-│  ├─ compression@1.7.4
-│  │  └─ URL: https://github.com/expressjs/compression.git
-│  ├─ concat-map@0.0.1
-│  │  ├─ URL: git://github.com/substack/node-concat-map.git
-│  │  ├─ VendorName: James Halliday
-│  │  └─ VendorUrl: http://substack.net
-│  ├─ concat-stream@1.6.2
-│  │  ├─ URL: http://github.com/maxogden/concat-stream.git
-│  │  └─ VendorName: Max Ogden
-│  ├─ content-disposition@0.5.4
-│  │  ├─ URL: https://github.com/jshttp/content-disposition.git
-│  │  └─ VendorName: Douglas Christopher Wilson
-│  ├─ content-type@1.0.5
-│  │  ├─ URL: https://github.com/jshttp/content-type.git
-│  │  └─ VendorName: Douglas Christopher Wilson
-│  ├─ convert-source-map@1.9.0
-│  │  ├─ URL: git://github.com/thlorenz/convert-source-map.git
-│  │  ├─ VendorName: Thorsten Lorenz
-│  │  └─ VendorUrl: https://github.com/thlorenz/convert-source-map
-│  ├─ convert-source-map@2.0.0
-│  │  ├─ URL: git://github.com/thlorenz/convert-source-map.git
-│  │  ├─ VendorName: Thorsten Lorenz
-│  │  └─ VendorUrl: https://github.com/thlorenz/convert-source-map
-│  ├─ cookie-signature@1.0.6
-│  │  ├─ URL: https://github.com/visionmedia/node-cookie-signature.git
-│  │  └─ VendorName: TJ Holowaychuk
-│  ├─ cookie@0.5.0
-│  │  ├─ URL: https://github.com/jshttp/cookie.git
-│  │  └─ VendorName: Roman Shtylman
-│  ├─ core-js-compat@3.31.0
-│  │  ├─ URL: https://github.com/zloirock/core-js.git
-│  │  ├─ VendorName: Denis Pushkarev
-│  │  └─ VendorUrl: http://zloirock.ru
-│  ├─ core-js-pure@3.31.0
-│  │  ├─ URL: https://github.com/zloirock/core-js.git
-│  │  ├─ VendorName: Denis Pushkarev
-│  │  └─ VendorUrl: http://zloirock.ru
-│  ├─ core-util-is@1.0.3
-│  │  ├─ URL: git://github.com/isaacs/core-util-is
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me/
-│  ├─ cosmiconfig@7.1.0
-│  │  ├─ URL: git+https://github.com/davidtheclark/cosmiconfig.git
-│  │  ├─ VendorName: David Clark
-│  │  └─ VendorUrl: https://github.com/davidtheclark/cosmiconfig#readme
-│  ├─ cross-spawn@7.0.3
-│  │  ├─ URL: git@github.com:moxystudio/node-cross-spawn.git
-│  │  ├─ VendorName: André Cruz
-│  │  └─ VendorUrl: https://github.com/moxystudio/node-cross-spawn
-│  ├─ crypto-random-string@2.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/crypto-random-string.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ css-loader@6.8.1
-│  │  ├─ URL: https://github.com/webpack-contrib/css-loader.git
-│  │  ├─ VendorName: Tobias Koppers @sokra
-│  │  └─ VendorUrl: https://github.com/webpack-contrib/css-loader
-│  ├─ css-tree@1.1.3
-│  │  ├─ URL: https://github.com/csstree/csstree.git
-│  │  ├─ VendorName: Roman Dvornov
-│  │  └─ VendorUrl: https://github.com/lahmatiy
-│  ├─ cssesc@3.0.0
-│  │  ├─ URL: https://github.com/mathiasbynens/cssesc.git
-│  │  ├─ VendorName: Mathias Bynens
-│  │  └─ VendorUrl: https://mths.be/cssesc
-│  ├─ cssnano-preset-default@5.2.14
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ cssnano-utils@3.1.0
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ cssnano@5.1.15
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ csso@4.2.0
-│  │  ├─ URL: https://github.com/css/csso.git
-│  │  ├─ VendorName: Sergey Kryzhanovsky
-│  │  └─ VendorUrl: https://github.com/css/csso
-│  ├─ cssom@0.3.8
-│  │  ├─ URL: https://github.com/NV/CSSOM.git
-│  │  └─ VendorName: Nikita Vasilyev
-│  ├─ cssom@0.5.0
-│  │  ├─ URL: https://github.com/NV/CSSOM.git
-│  │  └─ VendorName: Nikita Vasilyev
-│  ├─ cssstyle@2.3.0
-│  │  ├─ URL: https://github.com/jsdom/cssstyle.git
-│  │  └─ VendorUrl: https://github.com/jsdom/cssstyle
-│  ├─ csstype@3.1.2
-│  │  ├─ URL: https://github.com/frenic/csstype
-│  │  └─ VendorName: Fredrik Nicol
-│  ├─ data-urls@3.0.2
-│  │  ├─ URL: https://github.com/jsdom/data-urls.git
-│  │  ├─ VendorName: Domenic Denicola
-│  │  └─ VendorUrl: https://domenic.me/
-│  ├─ date-fns@2.30.0
-│  │  └─ URL: https://github.com/date-fns/date-fns
-│  ├─ debug@2.6.9
-│  │  ├─ URL: git://github.com/visionmedia/debug.git
-│  │  └─ VendorName: TJ Holowaychuk
-│  ├─ debug@3.2.7
-│  │  ├─ URL: git://github.com/visionmedia/debug.git
-│  │  └─ VendorName: TJ Holowaychuk
-│  ├─ debug@4.3.4
-│  │  ├─ URL: git://github.com/debug-js/debug.git
-│  │  └─ VendorName: Josh Junon
-│  ├─ decimal.js@10.4.3
-│  │  ├─ URL: https://github.com/MikeMcl/decimal.js.git
-│  │  └─ VendorName: Michael Mclaughlin
-│  ├─ dedent@0.7.0
-│  │  ├─ URL: git://github.com/dmnd/dedent.git
-│  │  ├─ VendorName: Desmond Brand
-│  │  └─ VendorUrl: https://github.com/dmnd/dedent
-│  ├─ deep-equal@2.2.1
-│  │  ├─ URL: http://github.com/inspect-js/node-deep-equal.git
-│  │  ├─ VendorName: James Halliday
-│  │  └─ VendorUrl: http://substack.net
-│  ├─ deep-is@0.1.4
-│  │  ├─ URL: http://github.com/thlorenz/deep-is.git
-│  │  ├─ VendorName: Thorsten Lorenz
-│  │  └─ VendorUrl: http://thlorenz.com
-│  ├─ deepmerge@4.3.1
-│  │  ├─ URL: git://github.com/TehShrike/deepmerge.git
-│  │  └─ VendorUrl: https://github.com/TehShrike/deepmerge
-│  ├─ default-browser-id@3.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/default-browser-id.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ defaults@1.0.4
-│  │  ├─ URL: git://github.com/sindresorhus/node-defaults.git
-│  │  └─ VendorName: Elijah Insua
-│  ├─ define-lazy-prop@2.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/define-lazy-prop.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ define-properties@1.2.0
-│  │  ├─ URL: git://github.com/ljharb/define-properties.git
-│  │  └─ VendorName: Jordan Harband
-│  ├─ defu@6.1.2
-│  │  └─ URL: https://github.com/unjs/defu.git
-│  ├─ del@6.1.1
-│  │  ├─ URL: https://github.com/sindresorhus/del.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ delayed-stream@1.0.0
-│  │  ├─ URL: git://github.com/felixge/node-delayed-stream.git
-│  │  ├─ VendorName: Felix Geisendörfer
-│  │  └─ VendorUrl: https://github.com/felixge/node-delayed-stream
-│  ├─ delegates@1.0.0
-│  │  └─ URL: https://github.com/visionmedia/node-delegates.git
-│  ├─ depd@2.0.0
-│  │  ├─ URL: https://github.com/dougwilson/nodejs-depd.git
-│  │  └─ VendorName: Douglas Christopher Wilson
-│  ├─ dequal@2.0.3
-│  │  ├─ URL: https://github.com/lukeed/dequal.git
-│  │  ├─ VendorName: Luke Edwards
-│  │  └─ VendorUrl: https://lukeed.com
-│  ├─ destroy@1.2.0
-│  │  ├─ URL: https://github.com/stream-utils/destroy.git
-│  │  ├─ VendorName: Jonathan Ong
-│  │  └─ VendorUrl: http://jongleberry.com
-│  ├─ detect-indent@6.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/detect-indent.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ detect-newline@3.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/detect-newline.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ detect-package-manager@2.0.1
-│  │  ├─ URL: https://github.com/egoist/detect-package-manager.git
-│  │  └─ VendorName: egoist
-│  ├─ detect-port@1.5.1
-│  │  ├─ URL: git://github.com/node-modules/detect-port.git
-│  │  └─ VendorUrl: https://github.com/node-modules/detect-port
-│  ├─ diff-sequences@28.1.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ dir-glob@3.0.1
-│  │  ├─ URL: https://github.com/kevva/dir-glob.git
-│  │  ├─ VendorName: Kevin Mårtensson
-│  │  └─ VendorUrl: github.com/kevva
-│  ├─ dom-accessibility-api@0.5.16
-│  │  └─ URL: https://github.com/eps1lon/dom-accessibility-api.git
-│  ├─ dom-converter@0.2.0
-│  │  ├─ URL: https://github.com/AriaMinaei/dom-converter
-│  │  └─ VendorName: Aria Minaei
-│  ├─ dom-helpers@5.2.1
-│  │  ├─ URL: git+https://github.com/react-bootstrap/dom-helpers.git
-│  │  ├─ VendorName: Jason Quense
-│  │  └─ VendorUrl: https://github.com/react-bootstrap/dom-helpers#readme
-│  ├─ dom-serializer@1.4.1
-│  │  ├─ URL: git://github.com/cheeriojs/dom-renderer.git
-│  │  └─ VendorName: Felix Boehm
-│  ├─ domexception@4.0.0
-│  │  ├─ URL: https://github.com/jsdom/domexception.git
-│  │  ├─ VendorName: Domenic Denicola
-│  │  └─ VendorUrl: https://domenic.me/
-│  ├─ dot-case@3.0.4
-│  │  ├─ URL: git://github.com/blakeembrey/change-case.git
-│  │  ├─ VendorName: Blake Embrey
-│  │  └─ VendorUrl: https://github.com/blakeembrey/change-case/tree/master/packages/dot-case#readme
-│  ├─ duplexify@3.7.1
-│  │  ├─ URL: git://github.com/mafintosh/duplexify
-│  │  ├─ VendorName: Mathias Buus
-│  │  └─ VendorUrl: https://github.com/mafintosh/duplexify
-│  ├─ eastasianwidth@0.2.0
-│  │  ├─ URL: git://github.com/komagata/eastasianwidth.git
-│  │  └─ VendorName: Masaki Komagata
-│  ├─ ee-first@1.1.1
-│  │  ├─ URL: https://github.com/jonathanong/ee-first.git
-│  │  ├─ VendorName: Jonathan Ong
-│  │  └─ VendorUrl: http://jongleberry.com
-│  ├─ emittery@0.10.2
-│  │  ├─ URL: https://github.com/sindresorhus/emittery.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ emoji-regex@8.0.0
-│  │  ├─ URL: https://github.com/mathiasbynens/emoji-regex.git
-│  │  ├─ VendorName: Mathias Bynens
-│  │  └─ VendorUrl: https://mths.be/emoji-regex
-│  ├─ emoji-regex@9.2.2
-│  │  ├─ URL: https://github.com/mathiasbynens/emoji-regex.git
-│  │  ├─ VendorName: Mathias Bynens
-│  │  └─ VendorUrl: https://mths.be/emoji-regex
-│  ├─ emojis-list@3.0.0
-│  │  ├─ URL: git+https://github.com/kikobeats/emojis-list.git
-│  │  ├─ VendorName: Kiko Beats
-│  │  └─ VendorUrl: https://nidecoc.io/Kikobeats/emojis-list
-│  ├─ encodeurl@1.0.2
-│  │  └─ URL: https://github.com/pillarjs/encodeurl.git
-│  ├─ end-of-stream@1.4.4
-│  │  ├─ URL: git://github.com/mafintosh/end-of-stream.git
-│  │  ├─ VendorName: Mathias Buus
-│  │  └─ VendorUrl: https://github.com/mafintosh/end-of-stream
-│  ├─ endent@2.1.0
-│  │  ├─ URL: git://github.com/ZhouHansen/endent.git
-│  │  ├─ VendorName: zhouhancheng
-│  │  └─ VendorUrl: https://github.com/ZhouHansen/endent#readme
-│  ├─ enhanced-resolve@5.15.0
-│  │  ├─ URL: git://github.com/webpack/enhanced-resolve.git
-│  │  ├─ VendorName: Tobias Koppers @sokra
-│  │  └─ VendorUrl: http://github.com/webpack/enhanced-resolve
-│  ├─ enquire.js@2.1.6
-│  │  ├─ URL: git://github.com/WickyNilliams/enquire.js.git
-│  │  ├─ VendorName: Nick Williams
-│  │  └─ VendorUrl: http://wicky.nillia.ms/enquire.js
-│  ├─ envinfo@7.8.1
-│  │  ├─ URL: https://github.com/tabrindle/envinfo
-│  │  └─ VendorName: tabrindle@gmail.com
-│  ├─ error-ex@1.3.2
-│  │  └─ URL: https://github.com/qix-/node-error-ex.git
-│  ├─ error-stack-parser@2.1.4
-│  │  ├─ URL: git://github.com/stacktracejs/error-stack-parser.git
-│  │  └─ VendorUrl: https://www.stacktracejs.com/
-│  ├─ es-abstract@1.21.2
-│  │  ├─ URL: git://github.com/ljharb/es-abstract.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: http://ljharb.codes
-│  ├─ es-get-iterator@1.1.3
-│  │  ├─ URL: git+https://github.com/ljharb/es-get-iterator.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/ljharb/es-get-iterator#readme
-│  ├─ es-module-lexer@1.3.0
-│  │  ├─ URL: git+https://github.com/guybedford/es-module-lexer.git
-│  │  ├─ VendorName: Guy Bedford
-│  │  └─ VendorUrl: https://github.com/guybedford/es-module-lexer#readme
-│  ├─ es-set-tostringtag@2.0.1
-│  │  ├─ URL: git+https://github.com/es-shims/es-set-tostringtag.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/es-shims/es-set-tostringtag#readme
-│  ├─ es-shim-unscopables@1.0.0
-│  │  ├─ URL: git+https://github.com/ljharb/es-shim-unscopables.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/ljharb/es-shim-unscopables#readme
-│  ├─ es-to-primitive@1.2.1
-│  │  ├─ URL: git://github.com/ljharb/es-to-primitive.git
-│  │  └─ VendorName: Jordan Harband
-│  ├─ es6-object-assign@1.1.0
-│  │  ├─ URL: https://github.com/rubennorte/es6-object-assign.git
-│  │  ├─ VendorName: Rubén Norte
-│  │  └─ VendorUrl: https://github.com/rubennorte/es6-object-assign
-│  ├─ esbuild-plugin-alias@0.2.1
-│  │  ├─ URL: git+https://github.com/igoradamenko/esbuild-plugin-alias.git
-│  │  ├─ VendorName: Igor Adamenko
-│  │  └─ VendorUrl: https://github.com/igoradamenko/esbuild-plugin-alias#readme
-│  ├─ esbuild-register@3.4.2
-│  ├─ esbuild@0.17.19
-│  │  └─ URL: https://github.com/evanw/esbuild
-│  ├─ escalade@3.1.1
-│  │  ├─ URL: https://github.com/lukeed/escalade.git
-│  │  ├─ VendorName: Luke Edwards
-│  │  └─ VendorUrl: https://lukeed.com
-│  ├─ escape-html@1.0.3
-│  │  └─ URL: https://github.com/component/escape-html.git
-│  ├─ escape-string-regexp@1.0.5
-│  │  ├─ URL: https://github.com/sindresorhus/escape-string-regexp.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ escape-string-regexp@2.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/escape-string-regexp.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ escape-string-regexp@4.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/escape-string-regexp.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ eslint-config-prettier@8.8.0
-│  │  ├─ URL: https://github.com/prettier/eslint-config-prettier.git
-│  │  └─ VendorName: Simon Lydell
-│  ├─ eslint-config-standard-with-typescript@34.0.1
-│  │  ├─ URL: git+https://github.com/standard/eslint-config-standard-with-typescript.git
-│  │  ├─ VendorName: Shahar Or
-│  │  └─ VendorUrl: https://github.com/standard/eslint-config-standard-with-typescript#readme
-│  ├─ eslint-config-standard@17.0.0
-│  │  ├─ URL: git://github.com/standard/eslint-config-standard.git
-│  │  ├─ VendorName: Feross Aboukhadijeh
-│  │  └─ VendorUrl: https://github.com/standard/eslint-config-standard
-│  ├─ eslint-import-resolver-node@0.3.7
-│  │  ├─ URL: https://github.com/import-js/eslint-plugin-import
-│  │  ├─ VendorName: Ben Mosher
-│  │  └─ VendorUrl: https://github.com/import-js/eslint-plugin-import
-│  ├─ eslint-module-utils@2.8.0
-│  │  ├─ URL: git+https://github.com/import-js/eslint-plugin-import.git
-│  │  ├─ VendorName: Ben Mosher
-│  │  └─ VendorUrl: https://github.com/import-js/eslint-plugin-import#readme
-│  ├─ eslint-plugin-es@4.1.0
-│  │  ├─ URL: git+https://github.com/mysticatea/eslint-plugin-es.git
-│  │  ├─ VendorName: Toru Nagashima
-│  │  └─ VendorUrl: https://github.com/mysticatea/eslint-plugin-es#readme
-│  ├─ eslint-plugin-import@2.27.5
-│  │  ├─ URL: https://github.com/import-js/eslint-plugin-import
-│  │  ├─ VendorName: Ben Mosher
-│  │  └─ VendorUrl: https://github.com/import-js/eslint-plugin-import
-│  ├─ eslint-plugin-n@15.7.0
-│  │  ├─ URL: git+https://github.com/eslint-community/eslint-plugin-n.git
-│  │  ├─ VendorName: Toru Nagashima
-│  │  └─ VendorUrl: https://github.com/eslint-community/eslint-plugin-n#readme
-│  ├─ eslint-plugin-react-hooks@4.6.0
-│  │  ├─ URL: https://github.com/facebook/react.git
-│  │  └─ VendorUrl: https://reactjs.org/
-│  ├─ eslint-plugin-react@7.32.2
-│  │  ├─ URL: https://github.com/jsx-eslint/eslint-plugin-react
-│  │  ├─ VendorName: Yannick Croissant
-│  │  └─ VendorUrl: https://github.com/jsx-eslint/eslint-plugin-react
-│  ├─ eslint-utils@2.1.0
-│  │  ├─ URL: git+https://github.com/mysticatea/eslint-utils.git
-│  │  ├─ VendorName: Toru Nagashima
-│  │  └─ VendorUrl: https://github.com/mysticatea/eslint-utils#readme
-│  ├─ eslint-utils@3.0.0
-│  │  ├─ URL: git+https://github.com/mysticatea/eslint-utils.git
-│  │  ├─ VendorName: Toru Nagashima
-│  │  └─ VendorUrl: https://github.com/mysticatea/eslint-utils#readme
-│  ├─ eslint@8.37.0
-│  │  ├─ URL: https://github.com/eslint/eslint.git
-│  │  ├─ VendorName: Nicholas C. Zakas
-│  │  └─ VendorUrl: https://eslint.org/
-│  ├─ estree-to-babel@3.2.1
-│  │  ├─ URL: git://github.com/coderaiser/estree-to-babel.git
-│  │  ├─ VendorName: coderaiser
-│  │  └─ VendorUrl: http://github.com/coderaiser/estree-to-babel
-│  ├─ estree-walker@0.2.1
-│  │  └─ VendorName: Rich Harris
-│  ├─ estree-walker@0.6.1
-│  │  ├─ URL: https://github.com/Rich-Harris/estree-walker
-│  │  └─ VendorName: Rich Harris
-│  ├─ estree-walker@2.0.2
-│  │  ├─ URL: https://github.com/Rich-Harris/estree-walker
-│  │  └─ VendorName: Rich Harris
-│  ├─ etag@1.8.1
-│  │  └─ URL: https://github.com/jshttp/etag.git
-│  ├─ eventemitter3@4.0.7
-│  │  ├─ URL: git://github.com/primus/eventemitter3.git
-│  │  └─ VendorName: Arnout Kazemier
-│  ├─ events@3.3.0
-│  │  ├─ URL: git://github.com/Gozala/events.git
-│  │  ├─ VendorName: Irakli Gozalishvili
-│  │  └─ VendorUrl: http://jeditoolkit.com
-│  ├─ execa@5.1.1
-│  │  ├─ URL: https://github.com/sindresorhus/execa.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ execa@7.1.1
-│  │  ├─ URL: https://github.com/sindresorhus/execa.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ exit@0.1.2
-│  │  ├─ URL: git://github.com/cowboy/node-exit.git
-│  │  ├─ VendorName: "Cowboy" Ben Alman
-│  │  └─ VendorUrl: https://github.com/cowboy/node-exit
-│  ├─ expect@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ express@4.18.2
-│  │  ├─ URL: https://github.com/expressjs/express.git
-│  │  ├─ VendorName: TJ Holowaychuk
-│  │  └─ VendorUrl: http://expressjs.com/
-│  ├─ extend@3.0.2
-│  │  ├─ URL: https://github.com/justmoon/node-extend.git
-│  │  ├─ VendorName: Stefan Thomas
-│  │  └─ VendorUrl: http://www.justmoon.net
-│  ├─ fast-deep-equal@3.1.3
-│  │  ├─ URL: git+https://github.com/epoberezkin/fast-deep-equal.git
-│  │  ├─ VendorName: Evgeny Poberezkin
-│  │  └─ VendorUrl: https://github.com/epoberezkin/fast-deep-equal#readme
-│  ├─ fast-glob@3.2.12
-│  │  ├─ URL: https://github.com/mrmlnc/fast-glob.git
-│  │  ├─ VendorName: Denis Malinochkin
-│  │  └─ VendorUrl: https://mrmlnc.com
-│  ├─ fast-json-parse@1.0.3
-│  │  ├─ URL: git+https://github.com/mcollina/fast-json-parse.git
-│  │  ├─ VendorName: Matteo Collina
-│  │  └─ VendorUrl: https://github.com/mcollina/fast-json-parse#readme
-│  ├─ fast-json-stable-stringify@2.1.0
-│  │  ├─ URL: git://github.com/epoberezkin/fast-json-stable-stringify.git
-│  │  ├─ VendorName: James Halliday
-│  │  └─ VendorUrl: https://github.com/epoberezkin/fast-json-stable-stringify
-│  ├─ fast-levenshtein@2.0.6
-│  │  ├─ URL: https://github.com/hiddentao/fast-levenshtein.git
-│  │  ├─ VendorName: Ramesh Nair
-│  │  └─ VendorUrl: http://www.hiddentao.com/
-│  ├─ fd-slicer@1.1.0
-│  │  ├─ URL: git://github.com/andrewrk/node-fd-slicer.git
-│  │  └─ VendorName: Andrew Kelley
-│  ├─ fetch-retry@5.0.6
-│  │  ├─ URL: https://github.com/jonbern/fetch-retry.git
-│  │  └─ VendorName: Jon K. Bernhardsen
-│  ├─ file-entry-cache@6.0.1
-│  │  ├─ URL: https://github.com/royriojas/file-entry-cache.git
-│  │  ├─ VendorName: Roy Riojas
-│  │  └─ VendorUrl: http://royriojas.com
-│  ├─ file-system-cache@2.3.0
-│  │  ├─ URL: https://github.com/philcockfield/file-system-cache
-│  │  ├─ VendorName: Phil Cockfield
-│  │  └─ VendorUrl: https://github.com/philcockfield/file-system-cache
-│  ├─ fill-range@7.0.1
-│  │  ├─ URL: https://github.com/jonschlinkert/fill-range.git
-│  │  ├─ VendorName: Jon Schlinkert
-│  │  └─ VendorUrl: https://github.com/jonschlinkert/fill-range
-│  ├─ finalhandler@1.2.0
-│  │  ├─ URL: https://github.com/pillarjs/finalhandler.git
-│  │  └─ VendorName: Douglas Christopher Wilson
-│  ├─ find-cache-dir@2.1.0
-│  │  └─ URL: https://github.com/avajs/find-cache-dir.git
-│  ├─ find-cache-dir@3.3.2
-│  │  └─ URL: https://github.com/avajs/find-cache-dir.git
-│  ├─ find-root@1.1.0
-│  │  ├─ URL: git@github.com:js-n/find-root.git
-│  │  └─ VendorName: jsdnxx
-│  ├─ find-up@3.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/find-up.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ find-up@4.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/find-up.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ find-up@5.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/find-up.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ flat-cache@3.0.4
-│  │  ├─ URL: https://github.com/royriojas/flat-cache.git
-│  │  ├─ VendorName: Roy Riojas
-│  │  └─ VendorUrl: http://royriojas.com
-│  ├─ flow-parser@0.208.1
-│  │  ├─ URL: https://github.com/facebook/flow.git
-│  │  ├─ VendorName: Flow Team
-│  │  └─ VendorUrl: https://flow.org/
-│  ├─ for-each@0.3.3
-│  │  ├─ URL: git://github.com/Raynos/for-each.git
-│  │  ├─ VendorName: Raynos
-│  │  └─ VendorUrl: https://github.com/Raynos/for-each
-│  ├─ fork-ts-checker-webpack-plugin@7.3.0
-│  │  ├─ URL: https://github.com/TypeStrong/fork-ts-checker-webpack-plugin.git
-│  │  └─ VendorName: Piotr Oleś
-│  ├─ form-data@3.0.1
-│  │  ├─ URL: git://github.com/form-data/form-data.git
-│  │  ├─ VendorName: Felix Geisendörfer
-│  │  └─ VendorUrl: http://debuggable.com/
-│  ├─ form-data@4.0.0
-│  │  ├─ URL: git://github.com/form-data/form-data.git
-│  │  ├─ VendorName: Felix Geisendörfer
-│  │  └─ VendorUrl: http://debuggable.com/
-│  ├─ forwarded@0.2.0
-│  │  └─ URL: https://github.com/jshttp/forwarded.git
-│  ├─ fresh@0.5.2
-│  │  ├─ URL: https://github.com/jshttp/fresh.git
-│  │  ├─ VendorName: TJ Holowaychuk
-│  │  └─ VendorUrl: http://tjholowaychuk.com
-│  ├─ fs-constants@1.0.0
-│  │  ├─ URL: https://github.com/mafintosh/fs-constants.git
-│  │  ├─ VendorName: Mathias Buus
-│  │  └─ VendorUrl: https://github.com/mafintosh/fs-constants
-│  ├─ fs-extra@10.1.0
-│  │  ├─ URL: https://github.com/jprichardson/node-fs-extra
-│  │  ├─ VendorName: JP Richardson
-│  │  └─ VendorUrl: https://github.com/jprichardson/node-fs-extra
-│  ├─ fs-extra@11.1.1
-│  │  ├─ URL: https://github.com/jprichardson/node-fs-extra
-│  │  ├─ VendorName: JP Richardson
-│  │  └─ VendorUrl: https://github.com/jprichardson/node-fs-extra
-│  ├─ fsevents@2.3.2
-│  │  ├─ URL: https://github.com/fsevents/fsevents.git
-│  │  └─ VendorUrl: https://github.com/fsevents/fsevents
-│  ├─ function-bind@1.1.1
-│  │  ├─ URL: git://github.com/Raynos/function-bind.git
-│  │  ├─ VendorName: Raynos
-│  │  └─ VendorUrl: https://github.com/Raynos/function-bind
-│  ├─ function.prototype.name@1.1.5
-│  │  ├─ URL: git://github.com/es-shims/Function.prototype.name.git
-│  │  └─ VendorName: Jordan Harband
-│  ├─ functions-have-names@1.2.3
-│  │  ├─ URL: git+https://github.com/inspect-js/functions-have-names.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/functions-have-names#readme
-│  ├─ generic-names@4.0.0
-│  │  ├─ URL: git+https://github.com/css-modules/generic-names.git
-│  │  ├─ VendorName: Alexey Litvinov
-│  │  └─ VendorUrl: https://github.com/css-modules/generic-names#readme
-│  ├─ gensync@1.0.0-beta.2
-│  │  ├─ URL: https://github.com/loganfsmyth/gensync.git
-│  │  ├─ VendorName: Logan Smyth
-│  │  └─ VendorUrl: https://github.com/loganfsmyth/gensync
-│  ├─ get-intrinsic@1.2.1
-│  │  ├─ URL: git+https://github.com/ljharb/get-intrinsic.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/ljharb/get-intrinsic#readme
-│  ├─ get-npm-tarball-url@2.0.3
-│  │  ├─ URL: git+https://github.com/pnpm/get-npm-tarball-url.git
-│  │  ├─ VendorName: Zoltan Kochan
-│  │  └─ VendorUrl: https://github.com/pnpm/get-npm-tarball-url#readme
-│  ├─ get-package-type@0.1.0
-│  │  ├─ URL: git+https://github.com/cfware/get-package-type.git
-│  │  ├─ VendorName: Corey Farrell
-│  │  └─ VendorUrl: https://github.com/cfware/get-package-type#readme
-│  ├─ get-port@5.1.1
-│  │  ├─ URL: https://github.com/sindresorhus/get-port.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ get-stream@6.0.1
-│  │  ├─ URL: https://github.com/sindresorhus/get-stream.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ get-symbol-description@1.0.0
-│  │  ├─ URL: git+https://github.com/inspect-js/get-symbol-description.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/get-symbol-description#readme
-│  ├─ giget@1.1.2
-│  │  └─ URL: https://github.com/unjs/giget.git
-│  ├─ glob-promise@6.0.3
-│  │  ├─ URL: https://github.com/ahmadnassri/node-glob-promise.git
-│  │  ├─ VendorName: Ahmad Nassri
-│  │  └─ VendorUrl: https://github.com/ahmadnassri/node-glob-promise
-│  ├─ globals@11.12.0
-│  │  ├─ URL: https://github.com/sindresorhus/globals.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ globals@13.20.0
-│  │  ├─ URL: https://github.com/sindresorhus/globals.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ globalthis@1.0.3
-│  │  ├─ URL: git://github.com/ljharb/System.global.git
-│  │  └─ VendorName: Jordan Harband
-│  ├─ globby@11.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/globby.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ gopd@1.0.1
-│  │  ├─ URL: git+https://github.com/ljharb/gopd.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/ljharb/gopd#readme
-│  ├─ grapheme-splitter@1.0.4
-│  │  ├─ URL: https://github.com/orling/grapheme-splitter.git
-│  │  ├─ VendorName: Orlin Georgiev
-│  │  └─ VendorUrl: https://github.com/orling/grapheme-splitter
-│  ├─ gunzip-maybe@1.4.2
-│  │  ├─ URL: https://github.com/mafintosh/gunzip-maybe
-│  │  ├─ VendorName: Mathias Buus
-│  │  └─ VendorUrl: https://github.com/mafintosh/gunzip-maybe
-│  ├─ handlebars@4.7.7
-│  │  ├─ URL: https://github.com/wycats/handlebars.js.git
-│  │  ├─ VendorName: Yehuda Katz
-│  │  └─ VendorUrl: http://www.handlebarsjs.com/
-│  ├─ has-bigints@1.0.2
-│  │  ├─ URL: git+https://github.com/ljharb/has-bigints.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/ljharb/has-bigints#readme
-│  ├─ has-flag@3.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/has-flag.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ has-flag@4.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/has-flag.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ has-property-descriptors@1.0.0
-│  │  ├─ URL: git+https://github.com/inspect-js/has-property-descriptors.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/has-property-descriptors#readme
-│  ├─ has-proto@1.0.1
-│  │  ├─ URL: git+https://github.com/inspect-js/has-proto.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/has-proto#readme
-│  ├─ has-symbols@1.0.3
-│  │  ├─ URL: git://github.com/inspect-js/has-symbols.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/ljharb/has-symbols#readme
-│  ├─ has-tostringtag@1.0.0
-│  │  ├─ URL: git+https://github.com/inspect-js/has-tostringtag.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/has-tostringtag#readme
-│  ├─ has@1.0.3
-│  │  ├─ URL: git://github.com/tarruda/has.git
-│  │  ├─ VendorName: Thiago de Arruda
-│  │  └─ VendorUrl: https://github.com/tarruda/has
-│  ├─ he@1.2.0
-│  │  ├─ URL: https://github.com/mathiasbynens/he.git
-│  │  ├─ VendorName: Mathias Bynens
-│  │  └─ VendorUrl: https://mths.be/he
-│  ├─ html-encoding-sniffer@3.0.0
-│  │  ├─ URL: https://github.com/jsdom/html-encoding-sniffer.git
-│  │  ├─ VendorName: Domenic Denicola
-│  │  └─ VendorUrl: https://domenic.me/
-│  ├─ html-entities@2.3.6
-│  │  ├─ URL: https://github.com/mdevils/html-entities.git
-│  │  └─ VendorName: Marat Dulin
-│  ├─ html-escaper@2.0.2
-│  │  ├─ URL: https://github.com/WebReflection/html-escaper.git
-│  │  ├─ VendorName: Andrea Giammarchi
-│  │  └─ VendorUrl: https://github.com/WebReflection/html-escaper
-│  ├─ html-minifier-terser@6.1.0
-│  │  ├─ URL: git+https://github.com/terser/html-minifier-terser.git
-│  │  ├─ VendorName: Daniel Ruf
-│  │  └─ VendorUrl: https://terser.org/html-minifier-terser/
-│  ├─ html-tags@3.3.1
-│  │  ├─ URL: https://github.com/sindresorhus/html-tags.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ html-webpack-plugin@5.5.3
-│  │  ├─ URL: https://github.com/jantimon/html-webpack-plugin.git
-│  │  ├─ VendorName: Jan Nicklas
-│  │  └─ VendorUrl: https://github.com/jantimon/html-webpack-plugin
-│  ├─ htmlparser2@6.1.0
-│  │  ├─ URL: git://github.com/fb55/htmlparser2.git
-│  │  └─ VendorName: Felix Boehm
-│  ├─ http-errors@2.0.0
-│  │  ├─ URL: https://github.com/jshttp/http-errors.git
-│  │  ├─ VendorName: Jonathan Ong
-│  │  └─ VendorUrl: http://jongleberry.com
-│  ├─ http-proxy-agent@5.0.0
-│  │  ├─ URL: git://github.com/TooTallNate/node-http-proxy-agent.git
-│  │  ├─ VendorName: Nathan Rajlich
-│  │  └─ VendorUrl: http://n8.io/
-│  ├─ https-proxy-agent@4.0.0
-│  │  ├─ URL: git://github.com/TooTallNate/node-https-proxy-agent.git
-│  │  ├─ VendorName: Nathan Rajlich
-│  │  └─ VendorUrl: http://n8.io/
-│  ├─ https-proxy-agent@5.0.1
-│  │  ├─ URL: git://github.com/TooTallNate/node-https-proxy-agent.git
-│  │  ├─ VendorName: Nathan Rajlich
-│  │  └─ VendorUrl: http://n8.io/
-│  ├─ husky@8.0.3
-│  │  ├─ URL: https://github.com/typicode/husky.git
-│  │  ├─ VendorName: Typicode
-│  │  └─ VendorUrl: https://typicode.github.io/husky
-│  ├─ iconv-lite@0.4.24
-│  │  ├─ URL: git://github.com/ashtuchkin/iconv-lite.git
-│  │  ├─ VendorName: Alexander Shtuchkin
-│  │  └─ VendorUrl: https://github.com/ashtuchkin/iconv-lite
-│  ├─ iconv-lite@0.6.3
-│  │  ├─ URL: git://github.com/ashtuchkin/iconv-lite.git
-│  │  ├─ VendorName: Alexander Shtuchkin
-│  │  └─ VendorUrl: https://github.com/ashtuchkin/iconv-lite
-│  ├─ identity-obj-proxy@3.0.0
-│  │  ├─ URL: git+https://github.com/keyanzhang/identity-obj-proxy.git
-│  │  ├─ VendorName: Keyan Zhang
-│  │  └─ VendorUrl: https://github.com/keyanzhang/identity-obj-proxy#readme
-│  ├─ ignore@5.2.4
-│  │  ├─ URL: git@github.com:kaelzhang/node-ignore.git
-│  │  └─ VendorName: kael
-│  ├─ immutable@4.3.0
-│  │  ├─ URL: git://github.com/immutable-js/immutable-js.git
-│  │  ├─ VendorName: Lee Byron
-│  │  └─ VendorUrl: https://immutable-js.com/
-│  ├─ import-cwd@3.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/import-cwd.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ import-fresh@3.3.0
-│  │  ├─ URL: https://github.com/sindresorhus/import-fresh.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ import-from@3.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/import-from.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ import-local@3.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/import-local.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ imurmurhash@0.1.4
-│  │  ├─ URL: https://github.com/jensyt/imurmurhash-js
-│  │  ├─ VendorName: Jens Taylor
-│  │  └─ VendorUrl: https://github.com/jensyt/imurmurhash-js
-│  ├─ indent-string@4.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/indent-string.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ internal-slot@1.0.5
-│  │  ├─ URL: git+https://github.com/ljharb/internal-slot.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/ljharb/internal-slot#readme
-│  ├─ interpret@1.4.0
-│  │  ├─ URL: https://github.com/gulpjs/interpret.git
-│  │  ├─ VendorName: Gulp Team
-│  │  └─ VendorUrl: http://gulpjs.com/
-│  ├─ ip@2.0.0
-│  │  ├─ URL: http://github.com/indutny/node-ip.git
-│  │  ├─ VendorName: Fedor Indutny
-│  │  └─ VendorUrl: https://github.com/indutny/node-ip
-│  ├─ ipaddr.js@1.9.1
-│  │  ├─ URL: git://github.com/whitequark/ipaddr.js
-│  │  └─ VendorName: whitequark
-│  ├─ is-absolute-url@3.0.3
-│  │  ├─ URL: https://github.com/sindresorhus/is-absolute-url.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ is-arguments@1.1.1
-│  │  ├─ URL: git://github.com/inspect-js/is-arguments.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/is-arguments
-│  ├─ is-array-buffer@3.0.2
-│  │  ├─ URL: git+https://github.com/inspect-js/is-array-buffer.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/is-array-buffer#readme
-│  ├─ is-arrayish@0.2.1
-│  │  ├─ URL: https://github.com/qix-/node-is-arrayish.git
-│  │  ├─ VendorName: Qix
-│  │  └─ VendorUrl: http://github.com/qix-
-│  ├─ is-bigint@1.0.4
-│  │  ├─ URL: git+https://github.com/inspect-js/is-bigint.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/is-bigint#readme
-│  ├─ is-binary-path@2.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/is-binary-path.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ is-boolean-object@1.1.2
-│  │  ├─ URL: git://github.com/inspect-js/is-boolean-object.git
-│  │  └─ VendorName: Jordan Harband
-│  ├─ is-builtin-module@3.2.1
-│  │  ├─ URL: https://github.com/sindresorhus/is-builtin-module.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ is-callable@1.2.7
-│  │  ├─ URL: git://github.com/inspect-js/is-callable.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: http://ljharb.codes
-│  ├─ is-core-module@2.12.1
-│  │  ├─ URL: git+https://github.com/inspect-js/is-core-module.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/is-core-module
-│  ├─ is-date-object@1.0.5
-│  │  ├─ URL: git://github.com/inspect-js/is-date-object.git
-│  │  └─ VendorName: Jordan Harband
-│  ├─ is-deflate@1.0.0
-│  │  ├─ URL: git+https://github.com/watson/is-deflate.git
-│  │  ├─ VendorName: Thomas Watson Steen
-│  │  └─ VendorUrl: https://github.com/watson/is-deflate#readme
-│  ├─ is-docker@2.2.1
-│  │  ├─ URL: https://github.com/sindresorhus/is-docker.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ is-extglob@2.1.1
-│  │  ├─ URL: https://github.com/jonschlinkert/is-extglob.git
-│  │  ├─ VendorName: Jon Schlinkert
-│  │  └─ VendorUrl: https://github.com/jonschlinkert/is-extglob
-│  ├─ is-fullwidth-code-point@3.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/is-fullwidth-code-point.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ is-fullwidth-code-point@4.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/is-fullwidth-code-point.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ is-generator-fn@2.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/is-generator-fn.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ is-generator-function@1.0.10
-│  │  ├─ URL: git://github.com/inspect-js/is-generator-function.git
-│  │  └─ VendorName: Jordan Harband
-│  ├─ is-glob@4.0.3
-│  │  ├─ URL: https://github.com/micromatch/is-glob.git
-│  │  ├─ VendorName: Jon Schlinkert
-│  │  └─ VendorUrl: https://github.com/micromatch/is-glob
-│  ├─ is-gzip@1.0.0
-│  │  ├─ URL: https://github.com/kevva/is-gzip.git
-│  │  ├─ VendorName: Kevin Mårtensson
-│  │  └─ VendorUrl: https://github.com/kevva
-│  ├─ is-interactive@1.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/is-interactive.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ is-map@2.0.2
-│  │  ├─ URL: git+https://github.com/inspect-js/is-map.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/is-map#readme
-│  ├─ is-module@1.0.0
-│  │  ├─ URL: https://github.com/component/is-module.git
-│  │  ├─ VendorName: Jonathan Ong
-│  │  └─ VendorUrl: http://jongleberry.com
-│  ├─ is-nan@1.3.2
-│  │  ├─ URL: git://github.com/es-shims/is-nan.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/es-shims/is-nan
-│  ├─ is-negative-zero@2.0.2
-│  │  ├─ URL: git://github.com/inspect-js/is-negative-zero.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/is-negative-zero
-│  ├─ is-number-object@1.0.7
-│  │  ├─ URL: git://github.com/inspect-js/is-number-object.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/is-number-object#readme
-│  ├─ is-number@7.0.0
-│  │  ├─ URL: https://github.com/jonschlinkert/is-number.git
-│  │  ├─ VendorName: Jon Schlinkert
-│  │  └─ VendorUrl: https://github.com/jonschlinkert/is-number
-│  ├─ is-path-cwd@2.2.0
-│  │  ├─ URL: https://github.com/sindresorhus/is-path-cwd.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ is-path-inside@3.0.3
-│  │  ├─ URL: https://github.com/sindresorhus/is-path-inside.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ is-plain-object@2.0.4
-│  │  ├─ URL: https://github.com/jonschlinkert/is-plain-object.git
-│  │  ├─ VendorName: Jon Schlinkert
-│  │  └─ VendorUrl: https://github.com/jonschlinkert/is-plain-object
-│  ├─ is-plain-object@5.0.0
-│  │  ├─ URL: https://github.com/jonschlinkert/is-plain-object.git
-│  │  ├─ VendorName: Jon Schlinkert
-│  │  └─ VendorUrl: https://github.com/jonschlinkert/is-plain-object
-│  ├─ is-potential-custom-element-name@1.0.1
-│  │  ├─ URL: https://github.com/mathiasbynens/is-potential-custom-element-name.git
-│  │  ├─ VendorName: Mathias Bynens
-│  │  └─ VendorUrl: https://github.com/mathiasbynens/is-potential-custom-element-name
-│  ├─ is-reference@1.2.1
-│  │  ├─ URL: git+https://github.com/Rich-Harris/is-reference.git
-│  │  ├─ VendorName: Rich Harris
-│  │  └─ VendorUrl: https://github.com/Rich-Harris/is-reference#readme
-│  ├─ is-regex@1.1.4
-│  │  ├─ URL: git://github.com/inspect-js/is-regex.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/is-regex
-│  ├─ is-set@2.0.2
-│  │  ├─ URL: git+https://github.com/inspect-js/is-set.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/is-set#readme
-│  ├─ is-shared-array-buffer@1.0.2
-│  │  ├─ URL: git+https://github.com/inspect-js/is-shared-array-buffer.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/is-shared-array-buffer#readme
-│  ├─ is-stream@2.0.1
-│  │  ├─ URL: https://github.com/sindresorhus/is-stream.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ is-stream@3.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/is-stream.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ is-string@1.0.7
-│  │  ├─ URL: git://github.com/ljharb/is-string.git
-│  │  └─ VendorName: Jordan Harband
-│  ├─ is-symbol@1.0.4
-│  │  ├─ URL: git://github.com/inspect-js/is-symbol.git
-│  │  └─ VendorName: Jordan Harband
-│  ├─ is-typed-array@1.1.10
-│  │  ├─ URL: git://github.com/inspect-js/is-typed-array.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: http://ljharb.codes
-│  ├─ is-typedarray@1.0.0
-│  │  ├─ URL: git://github.com/hughsk/is-typedarray.git
-│  │  ├─ VendorName: Hugh Kennedy
-│  │  └─ VendorUrl: https://github.com/hughsk/is-typedarray
-│  ├─ is-unicode-supported@0.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/is-unicode-supported.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ is-weakmap@2.0.1
-│  │  ├─ URL: git+https://github.com/inspect-js/is-weakmap.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/is-weakmap#readme
-│  ├─ is-weakref@1.0.2
-│  │  ├─ URL: git+https://github.com/inspect-js/is-weakref.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/is-weakref#readme
-│  ├─ is-weakset@2.0.2
-│  │  ├─ URL: git+https://github.com/inspect-js/is-weakset.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/is-weakset#readme
-│  ├─ is-wsl@2.2.0
-│  │  ├─ URL: https://github.com/sindresorhus/is-wsl.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ isarray@1.0.0
-│  │  ├─ URL: git://github.com/juliangruber/isarray.git
-│  │  ├─ VendorName: Julian Gruber
-│  │  └─ VendorUrl: https://github.com/juliangruber/isarray
-│  ├─ isarray@2.0.5
-│  │  ├─ URL: git://github.com/juliangruber/isarray.git
-│  │  ├─ VendorName: Julian Gruber
-│  │  └─ VendorUrl: https://github.com/juliangruber/isarray
-│  ├─ isobject@3.0.1
-│  │  ├─ URL: https://github.com/jonschlinkert/isobject.git
-│  │  ├─ VendorName: Jon Schlinkert
-│  │  └─ VendorUrl: https://github.com/jonschlinkert/isobject
-│  ├─ isomorphic-unfetch@3.1.0
-│  │  └─ URL: https://github.com/developit/unfetch.git
-│  ├─ jest-changed-files@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-circus@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-cli@28.1.3
-│  │  ├─ URL: https://github.com/facebook/jest.git
-│  │  └─ VendorUrl: https://jestjs.io/
-│  ├─ jest-config@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-diff@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-docblock@28.1.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-each@28.1.3
-│  │  ├─ URL: https://github.com/facebook/jest.git
-│  │  ├─ VendorName: Matt Phillips
-│  │  └─ VendorUrl: mattphillips
-│  ├─ jest-environment-jsdom@29.5.0
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-environment-node@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-get-type@28.0.2
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-haste-map@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-haste-map@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-haste-map@29.5.0
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-leak-detector@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-matcher-utils@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-message-util@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-message-util@29.5.0
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-mock@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-mock@29.5.0
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-pnp-resolver@1.2.3
-│  │  ├─ URL: https://github.com/arcanis/jest-pnp-resolver.git
-│  │  └─ VendorUrl: https://github.com/arcanis/jest-pnp-resolver
-│  ├─ jest-regex-util@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-regex-util@28.0.2
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-regex-util@29.4.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-resolve-dependencies@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-resolve@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-runner@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-runtime@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-serializer@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-snapshot@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-util@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-util@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-util@29.5.0
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-validate@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-watcher@28.1.3
-│  │  ├─ URL: https://github.com/facebook/jest.git
-│  │  └─ VendorUrl: https://jestjs.io/
-│  ├─ jest-worker@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-worker@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-worker@29.5.0
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest@28.1.3
-│  │  ├─ URL: https://github.com/facebook/jest.git
-│  │  └─ VendorUrl: https://jestjs.io/
-│  ├─ jquery@3.7.0
-│  │  ├─ URL: https://github.com/jquery/jquery.git
-│  │  ├─ VendorName: OpenJS Foundation and other contributors
-│  │  └─ VendorUrl: https://jquery.com/
-│  ├─ js-sdsl@4.4.1
-│  │  ├─ URL: https://github.com/js-sdsl/js-sdsl.git
-│  │  ├─ VendorName: ZLY201
-│  │  └─ VendorUrl: https://js-sdsl.org/
-│  ├─ js-tokens@4.0.0
-│  │  ├─ URL: https://github.com/lydell/js-tokens.git
-│  │  └─ VendorName: Simon Lydell
-│  ├─ js-yaml@3.14.1
-│  │  ├─ URL: https://github.com/nodeca/js-yaml.git
-│  │  ├─ VendorName: Vladimir Zapparov
-│  │  └─ VendorUrl: https://github.com/nodeca/js-yaml
-│  ├─ js-yaml@4.1.0
-│  │  ├─ URL: https://github.com/nodeca/js-yaml.git
-│  │  └─ VendorName: Vladimir Zapparov
-│  ├─ jscodeshift@0.14.0
-│  │  ├─ URL: https://github.com/facebook/jscodeshift.git
-│  │  └─ VendorName: Felix Kling
-│  ├─ jsdom@20.0.3
-│  │  └─ URL: https://github.com/jsdom/jsdom.git
-│  ├─ jsesc@0.5.0
-│  │  ├─ URL: https://github.com/mathiasbynens/jsesc.git
-│  │  ├─ VendorName: Mathias Bynens
-│  │  └─ VendorUrl: http://mths.be/jsesc
-│  ├─ jsesc@2.5.2
-│  │  ├─ URL: https://github.com/mathiasbynens/jsesc.git
-│  │  ├─ VendorName: Mathias Bynens
-│  │  └─ VendorUrl: https://mths.be/jsesc
-│  ├─ json-parse-even-better-errors@2.3.1
-│  │  ├─ URL: https://github.com/npm/json-parse-even-better-errors
-│  │  └─ VendorName: Kat Marchán
-│  ├─ json-schema-traverse@0.4.1
-│  │  ├─ URL: git+https://github.com/epoberezkin/json-schema-traverse.git
-│  │  ├─ VendorName: Evgeny Poberezkin
-│  │  └─ VendorUrl: https://github.com/epoberezkin/json-schema-traverse#readme
-│  ├─ json-schema-traverse@1.0.0
-│  │  ├─ URL: git+https://github.com/epoberezkin/json-schema-traverse.git
-│  │  ├─ VendorName: Evgeny Poberezkin
-│  │  └─ VendorUrl: https://github.com/epoberezkin/json-schema-traverse#readme
-│  ├─ json-stable-stringify-without-jsonify@1.0.1
-│  │  ├─ URL: git://github.com/samn/json-stable-stringify.git
-│  │  ├─ VendorName: James Halliday
-│  │  └─ VendorUrl: https://github.com/samn/json-stable-stringify
-│  ├─ json2mq@0.2.0
-│  │  ├─ URL: https://github.com/akiran/json2mq
-│  │  ├─ VendorName: Kiran Abburi
-│  │  └─ VendorUrl: https://github.com/akiran/json2mq
-│  ├─ json5@1.0.2
-│  │  ├─ URL: git+https://github.com/json5/json5.git
-│  │  ├─ VendorName: Aseem Kishore
-│  │  └─ VendorUrl: http://json5.org/
-│  ├─ json5@2.2.3
-│  │  ├─ URL: git+https://github.com/json5/json5.git
-│  │  ├─ VendorName: Aseem Kishore
-│  │  └─ VendorUrl: http://json5.org/
-│  ├─ jsonfile@6.1.0
-│  │  ├─ URL: git@github.com:jprichardson/node-jsonfile.git
-│  │  └─ VendorName: JP Richardson
-│  ├─ jsx-ast-utils@3.3.3
-│  │  ├─ URL: https://github.com/jsx-eslint/jsx-ast-utils
-│  │  └─ VendorName: Ethan Cohen
-│  ├─ kind-of@6.0.3
-│  │  ├─ URL: https://github.com/jonschlinkert/kind-of.git
-│  │  ├─ VendorName: Jon Schlinkert
-│  │  └─ VendorUrl: https://github.com/jonschlinkert/kind-of
-│  ├─ kleur@3.0.3
-│  │  ├─ URL: https://github.com/lukeed/kleur.git
-│  │  ├─ VendorName: Luke Edwards
-│  │  └─ VendorUrl: lukeed.com
-│  ├─ klona@2.0.6
-│  │  ├─ URL: https://github.com/lukeed/klona.git
-│  │  ├─ VendorName: Luke Edwards
-│  │  └─ VendorUrl: https://lukeed.com
-│  ├─ leven@3.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/leven.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ levn@0.3.0
-│  │  ├─ URL: git://github.com/gkz/levn.git
-│  │  ├─ VendorName: George Zahariev
-│  │  └─ VendorUrl: https://github.com/gkz/levn
-│  ├─ levn@0.4.1
-│  │  ├─ URL: git://github.com/gkz/levn.git
-│  │  ├─ VendorName: George Zahariev
-│  │  └─ VendorUrl: https://github.com/gkz/levn
-│  ├─ lilconfig@2.1.0
-│  │  ├─ URL: https://github.com/antonk52/lilconfig
-│  │  └─ VendorName: antonk52
-│  ├─ lines-and-columns@1.2.4
-│  │  ├─ URL: https://github.com/eventualbuddha/lines-and-columns.git
-│  │  ├─ VendorName: Brian Donovan
-│  │  └─ VendorUrl: https://github.com/eventualbuddha/lines-and-columns#readme
-│  ├─ lint-staged@13.2.2
-│  │  ├─ URL: https://github.com/okonet/lint-staged
-│  │  └─ VendorName: Andrey Okonetchnikov
-│  ├─ listr2@5.0.8
-│  │  ├─ URL: https://github.com/cenk1cenk2/listr2
-│  │  ├─ VendorName: Cenk Kilic
-│  │  └─ VendorUrl: https://cenk.kilic.dev
-│  ├─ loader-runner@4.3.0
-│  │  ├─ URL: git+https://github.com/webpack/loader-runner.git
-│  │  ├─ VendorName: Tobias Koppers @sokra
-│  │  └─ VendorUrl: https://github.com/webpack/loader-runner#readme
-│  ├─ loader-utils@2.0.4
-│  │  ├─ URL: https://github.com/webpack/loader-utils.git
-│  │  └─ VendorName: Tobias Koppers @sokra
-│  ├─ loader-utils@3.2.1
-│  │  ├─ URL: https://github.com/webpack/loader-utils.git
-│  │  └─ VendorName: Tobias Koppers @sokra
-│  ├─ locate-path@3.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/locate-path.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ locate-path@5.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/locate-path.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ locate-path@6.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/locate-path.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ lodash.camelcase@4.3.0
-│  │  ├─ URL: https://github.com/lodash/lodash.git
-│  │  ├─ VendorName: John-David Dalton
-│  │  └─ VendorUrl: https://lodash.com/
-│  ├─ lodash.debounce@4.0.8
-│  │  ├─ URL: https://github.com/lodash/lodash.git
-│  │  ├─ VendorName: John-David Dalton
-│  │  └─ VendorUrl: https://lodash.com/
-│  ├─ lodash.memoize@4.1.2
-│  │  ├─ URL: https://github.com/lodash/lodash.git
-│  │  ├─ VendorName: John-David Dalton
-│  │  └─ VendorUrl: https://lodash.com/
-│  ├─ lodash.merge@4.6.2
-│  │  ├─ URL: https://github.com/lodash/lodash.git
-│  │  ├─ VendorName: John-David Dalton
-│  │  └─ VendorUrl: https://lodash.com/
-│  ├─ lodash.uniq@4.5.0
-│  │  ├─ URL: https://github.com/lodash/lodash.git
-│  │  ├─ VendorName: John-David Dalton
-│  │  └─ VendorUrl: https://lodash.com/
-│  ├─ lodash@4.17.21
-│  │  ├─ URL: https://github.com/lodash/lodash.git
-│  │  ├─ VendorName: John-David Dalton
-│  │  └─ VendorUrl: https://lodash.com/
-│  ├─ log-symbols@4.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/log-symbols.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ log-update@4.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/log-update.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ loose-envify@1.4.0
-│  │  ├─ URL: git://github.com/zertosh/loose-envify.git
-│  │  ├─ VendorName: Andres Suarez
-│  │  └─ VendorUrl: https://github.com/zertosh/loose-envify
-│  ├─ lower-case@2.0.2
-│  │  ├─ URL: git://github.com/blakeembrey/change-case.git
-│  │  ├─ VendorName: Blake Embrey
-│  │  └─ VendorUrl: https://github.com/blakeembrey/change-case/tree/master/packages/lower-case#readme
-│  ├─ lz-string@1.5.0
-│  │  ├─ URL: https://github.com/pieroxy/lz-string.git
-│  │  ├─ VendorName: pieroxy
-│  │  └─ VendorUrl: http://pieroxy.net/blog/pages/lz-string/index.html
-│  ├─ magic-string@0.27.0
-│  │  ├─ URL: https://github.com/rich-harris/magic-string
-│  │  └─ VendorName: Rich Harris
-│  ├─ make-dir@2.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/make-dir.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ make-dir@3.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/make-dir.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ map-or-similar@1.5.0
-│  │  ├─ URL: git+https://github.com/thinkloop/map-or-similar.git
-│  │  ├─ VendorName: Baz
-│  │  └─ VendorUrl: https://github.com/thinkloop/map-or-similar#readme
-│  ├─ markdown-to-jsx@7.2.1
-│  │  ├─ URL: https://github.com/probablyup/markdown-to-jsx.git
-│  │  ├─ VendorName: Evan Jacobs
-│  │  └─ VendorUrl: https://probablyup.github.io/markdown-to-jsx
-│  ├─ mdast-util-definitions@4.0.0
-│  │  ├─ URL: https://github.com/syntax-tree/mdast-util-definitions.git
-│  │  ├─ VendorName: Titus Wormer
-│  │  └─ VendorUrl: https://wooorm.com
-│  ├─ mdast-util-to-string@1.1.0
-│  │  ├─ URL: https://github.com/syntax-tree/mdast-util-to-string.git
-│  │  ├─ VendorName: Titus Wormer
-│  │  └─ VendorUrl: https://wooorm.com
-│  ├─ media-typer@0.3.0
-│  │  ├─ URL: https://github.com/jshttp/media-typer.git
-│  │  └─ VendorName: Douglas Christopher Wilson
-│  ├─ memoizerific@1.11.3
-│  │  ├─ URL: git+https://github.com/thinkloop/memoizerific.git
-│  │  ├─ VendorName: Baz
-│  │  └─ VendorUrl: https://github.com/thinkloop/memoizerific#readme
-│  ├─ merge-descriptors@1.0.1
-│  │  ├─ URL: https://github.com/component/merge-descriptors.git
-│  │  ├─ VendorName: Jonathan Ong
-│  │  └─ VendorUrl: http://jongleberry.com
-│  ├─ merge-stream@2.0.0
-│  │  ├─ URL: https://github.com/grncdr/merge-stream.git
-│  │  └─ VendorName: Stephen Sugden
-│  ├─ merge2@1.4.1
-│  │  ├─ URL: git@github.com:teambition/merge2.git
-│  │  └─ VendorUrl: https://github.com/teambition/merge2
-│  ├─ methods@1.1.2
-│  │  └─ URL: https://github.com/jshttp/methods.git
-│  ├─ micromatch@4.0.5
-│  │  ├─ URL: https://github.com/micromatch/micromatch.git
-│  │  ├─ VendorName: Jon Schlinkert
-│  │  └─ VendorUrl: https://github.com/micromatch/micromatch
-│  ├─ mime-db@1.52.0
-│  │  └─ URL: https://github.com/jshttp/mime-db.git
-│  ├─ mime-types@2.1.35
-│  │  └─ URL: https://github.com/jshttp/mime-types.git
-│  ├─ mime@1.6.0
-│  │  ├─ URL: https://github.com/broofa/node-mime
-│  │  ├─ VendorName: Robert Kieffer
-│  │  └─ VendorUrl: http://github.com/broofa
-│  ├─ mime@2.6.0
-│  │  ├─ URL: https://github.com/broofa/mime
-│  │  ├─ VendorName: Robert Kieffer
-│  │  └─ VendorUrl: http://github.com/broofa
-│  ├─ mimic-fn@2.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/mimic-fn.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ mimic-fn@4.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/mimic-fn.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ min-indent@1.0.1
-│  │  ├─ URL: https://github.com/thejameskyle/min-indent
-│  │  ├─ VendorName: James Kyle
-│  │  └─ VendorUrl: thejameskyle.com
-│  ├─ mini-svg-data-uri@1.4.4
-│  │  ├─ URL: git+https://github.com/tigt/mini-svg-data-uri.git
-│  │  ├─ VendorName: Taylor “Tigt” Hunt
-│  │  └─ VendorUrl: https://github.com/tigt/mini-svg-data-uri#readme
-│  ├─ minimist@1.2.8
-│  │  ├─ URL: git://github.com/minimistjs/minimist.git
-│  │  ├─ VendorName: James Halliday
-│  │  └─ VendorUrl: https://github.com/minimistjs/minimist
-│  ├─ minizlib@2.1.2
-│  │  ├─ URL: git+https://github.com/isaacs/minizlib.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me/
-│  ├─ mkdirp-classic@0.5.3
-│  │  ├─ URL: https://github.com/mafintosh/mkdirp-classic.git
-│  │  ├─ VendorName: Mathias Buus
-│  │  └─ VendorUrl: https://github.com/mafintosh/mkdirp-classic
-│  ├─ mkdirp@0.5.6
-│  │  ├─ URL: https://github.com/substack/node-mkdirp.git
-│  │  ├─ VendorName: James Halliday
-│  │  └─ VendorUrl: http://substack.net
-│  ├─ mkdirp@1.0.4
-│  │  └─ URL: https://github.com/isaacs/node-mkdirp.git
-│  ├─ mri@1.2.0
-│  │  ├─ URL: https://github.com/lukeed/mri.git
-│  │  ├─ VendorName: Luke Edwards
-│  │  └─ VendorUrl: https://lukeed.com
-│  ├─ ms@2.0.0
-│  │  └─ URL: https://github.com/zeit/ms.git
-│  ├─ ms@2.1.1
-│  │  └─ URL: https://github.com/zeit/ms.git
-│  ├─ ms@2.1.2
-│  │  └─ URL: https://github.com/zeit/ms.git
-│  ├─ ms@2.1.3
-│  │  └─ URL: https://github.com/vercel/ms.git
-│  ├─ nanoid@3.3.6
-│  │  ├─ URL: https://github.com/ai/nanoid.git
-│  │  └─ VendorName: Andrey Sitnik
-│  ├─ natural-compare-lite@1.4.0
-│  │  ├─ URL: git://github.com/litejs/natural-compare-lite.git
-│  │  ├─ VendorName: Lauri Rooden
-│  │  └─ VendorUrl: https://github.com/litejs/natural-compare-lite
-│  ├─ natural-compare@1.4.0
-│  │  ├─ URL: git://github.com/litejs/natural-compare-lite.git
-│  │  ├─ VendorName: Lauri Rooden
-│  │  └─ VendorUrl: https://github.com/litejs/natural-compare-lite
-│  ├─ negotiator@0.6.3
-│  │  └─ URL: https://github.com/jshttp/negotiator.git
-│  ├─ neo-async@2.6.2
-│  │  ├─ URL: git@github.com:suguru03/neo-async.git
-│  │  └─ VendorUrl: https://github.com/suguru03/neo-async
-│  ├─ no-case@3.0.4
-│  │  ├─ URL: git://github.com/blakeembrey/change-case.git
-│  │  ├─ VendorName: Blake Embrey
-│  │  └─ VendorUrl: https://github.com/blakeembrey/change-case/tree/master/packages/no-case#readme
-│  ├─ node-abort-controller@3.1.1
-│  │  ├─ URL: git+https://github.com/southpolesteve/node-abort-controller.git
-│  │  ├─ VendorName: Steve Faulkner
-│  │  └─ VendorUrl: https://github.com/southpolesteve/node-abort-controller#readme
-│  ├─ node-dir@0.1.17
-│  │  ├─ URL: https://github.com/fshost/node-dir
-│  │  ├─ VendorName: Nathan Cartwright
-│  │  └─ VendorUrl: https://github.com/fshost
-│  ├─ node-fetch-native@1.2.0
-│  │  └─ URL: https://github.com/unjs/node-fetch-native.git
-│  ├─ node-fetch@2.6.11
-│  │  ├─ URL: https://github.com/bitinn/node-fetch.git
-│  │  ├─ VendorName: David Frank
-│  │  └─ VendorUrl: https://github.com/bitinn/node-fetch
-│  ├─ node-int64@0.4.0
-│  │  ├─ URL: https://github.com/broofa/node-int64
-│  │  └─ VendorName: Robert Kieffer
-│  ├─ node-releases@2.0.12
-│  │  ├─ URL: https://github.com/chicoxyzzy/node-releases.git
-│  │  └─ VendorName: Sergey Rubanov
-│  ├─ normalize-path@3.0.0
-│  │  ├─ URL: https://github.com/jonschlinkert/normalize-path.git
-│  │  ├─ VendorName: Jon Schlinkert
-│  │  └─ VendorUrl: https://github.com/jonschlinkert/normalize-path
-│  ├─ normalize-url@6.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/normalize-url.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ npm-run-path@4.0.1
-│  │  ├─ URL: https://github.com/sindresorhus/npm-run-path.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ npm-run-path@5.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/npm-run-path.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ nwsapi@2.2.5
-│  │  ├─ URL: git://github.com/dperini/nwsapi.git
-│  │  ├─ VendorName: Diego Perini
-│  │  └─ VendorUrl: http://javascript.nwbox.com/nwsapi/
-│  ├─ object-assign@4.1.1
-│  │  ├─ URL: https://github.com/sindresorhus/object-assign.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ object-inspect@1.12.3
-│  │  ├─ URL: git://github.com/inspect-js/object-inspect.git
-│  │  ├─ VendorName: James Halliday
-│  │  └─ VendorUrl: https://github.com/inspect-js/object-inspect
-│  ├─ object-is@1.1.5
-│  │  ├─ URL: git://github.com/es-shims/object-is.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/es-shims/object-is
-│  ├─ object-keys@1.1.1
-│  │  ├─ URL: git://github.com/ljharb/object-keys.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: http://ljharb.codes
-│  ├─ object.assign@4.1.4
-│  │  ├─ URL: git://github.com/ljharb/object.assign.git
-│  │  └─ VendorName: Jordan Harband
-│  ├─ object.entries@1.1.6
-│  │  ├─ URL: git://github.com/es-shims/Object.entries.git
-│  │  └─ VendorName: Jordan Harband
-│  ├─ object.fromentries@2.0.6
-│  │  ├─ URL: git://github.com/es-shims/Object.fromEntries.git
-│  │  └─ VendorName: Jordan Harband
-│  ├─ object.hasown@1.1.2
-│  │  ├─ URL: https://github.com/es-shims/Object.hasOwn.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/es-shims/Object.hasOwn
-│  ├─ object.values@1.1.6
-│  │  ├─ URL: git://github.com/es-shims/Object.values.git
-│  │  └─ VendorName: Jordan Harband
-│  ├─ on-finished@2.4.1
-│  │  └─ URL: https://github.com/jshttp/on-finished.git
-│  ├─ on-headers@1.0.2
-│  │  ├─ URL: https://github.com/jshttp/on-headers.git
-│  │  └─ VendorName: Douglas Christopher Wilson
-│  ├─ onetime@5.1.2
-│  │  ├─ URL: https://github.com/sindresorhus/onetime.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ onetime@6.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/onetime.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ open@7.4.2
-│  │  ├─ URL: https://github.com/sindresorhus/open.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ open@8.4.2
-│  │  ├─ URL: https://github.com/sindresorhus/open.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ optionator@0.8.3
-│  │  ├─ URL: git://github.com/gkz/optionator.git
-│  │  ├─ VendorName: George Zahariev
-│  │  └─ VendorUrl: https://github.com/gkz/optionator
-│  ├─ optionator@0.9.1
-│  │  ├─ URL: git://github.com/gkz/optionator.git
-│  │  ├─ VendorName: George Zahariev
-│  │  └─ VendorUrl: https://github.com/gkz/optionator
-│  ├─ ora@5.4.1
-│  │  ├─ URL: https://github.com/sindresorhus/ora.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ p-finally@1.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/p-finally.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ p-limit@2.3.0
-│  │  ├─ URL: https://github.com/sindresorhus/p-limit.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ p-limit@3.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/p-limit.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ p-locate@3.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/p-locate.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ p-locate@4.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/p-locate.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ p-locate@5.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/p-locate.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ p-map@4.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/p-map.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ p-queue@6.6.2
-│  │  └─ URL: https://github.com/sindresorhus/p-queue.git
-│  ├─ p-timeout@3.2.0
-│  │  ├─ URL: https://github.com/sindresorhus/p-timeout.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ p-try@2.2.0
-│  │  ├─ URL: https://github.com/sindresorhus/p-try.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ pako@0.2.9
-│  │  ├─ URL: https://github.com/nodeca/pako.git
-│  │  └─ VendorUrl: https://github.com/nodeca/pako
-│  ├─ param-case@3.0.4
-│  │  ├─ URL: git://github.com/blakeembrey/change-case.git
-│  │  ├─ VendorName: Blake Embrey
-│  │  └─ VendorUrl: https://github.com/blakeembrey/change-case/tree/master/packages/param-case#readme
-│  ├─ parent-module@1.0.1
-│  │  ├─ URL: https://github.com/sindresorhus/parent-module.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ parse-json@5.2.0
-│  │  ├─ URL: https://github.com/sindresorhus/parse-json.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ parse5@7.1.2
-│  │  ├─ URL: git://github.com/inikulin/parse5.git
-│  │  ├─ VendorName: Ivan Nikulin
-│  │  └─ VendorUrl: https://github.com/inikulin/parse5
-│  ├─ parseurl@1.3.3
-│  │  └─ URL: https://github.com/pillarjs/parseurl.git
-│  ├─ pascal-case@3.1.2
-│  │  ├─ URL: git://github.com/blakeembrey/change-case.git
-│  │  ├─ VendorName: Blake Embrey
-│  │  └─ VendorUrl: https://github.com/blakeembrey/change-case/tree/master/packages/pascal-case#readme
-│  ├─ path-browserify@1.0.1
-│  │  ├─ URL: git://github.com/browserify/path-browserify.git
-│  │  ├─ VendorName: James Halliday
-│  │  └─ VendorUrl: https://github.com/browserify/path-browserify
-│  ├─ path-exists@3.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/path-exists.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ path-exists@4.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/path-exists.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ path-is-absolute@1.0.1
-│  │  ├─ URL: https://github.com/sindresorhus/path-is-absolute.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ path-key@3.1.1
-│  │  ├─ URL: https://github.com/sindresorhus/path-key.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ path-key@4.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/path-key.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ path-parse@1.0.7
-│  │  ├─ URL: https://github.com/jbgutierrez/path-parse.git
-│  │  ├─ VendorName: Javier Blanco
-│  │  └─ VendorUrl: https://github.com/jbgutierrez/path-parse#readme
-│  ├─ path-to-regexp@0.1.7
-│  │  └─ URL: https://github.com/component/path-to-regexp.git
-│  ├─ path-type@4.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/path-type.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ pathe@1.1.1
-│  │  └─ URL: https://github.com/unjs/pathe.git
-│  ├─ peek-stream@1.1.3
-│  │  ├─ URL: git://github.com/mafintosh/peek-stream
-│  │  ├─ VendorName: Mathias Buus
-│  │  └─ VendorUrl: https://github.com/mafintosh/peek-stream
-│  ├─ pend@1.2.0
-│  │  ├─ URL: git://github.com/andrewrk/node-pend.git
-│  │  └─ VendorName: Andrew Kelley
-│  ├─ picomatch@2.3.1
-│  │  ├─ URL: https://github.com/micromatch/picomatch.git
-│  │  ├─ VendorName: Jon Schlinkert
-│  │  └─ VendorUrl: https://github.com/micromatch/picomatch
-│  ├─ pidtree@0.6.0
-│  │  ├─ URL: https://github.com/simonepri/pidtree.git
-│  │  ├─ VendorName: Simone Primarosa
-│  │  └─ VendorUrl: http://github.com/simonepri/pidtree#readme
-│  ├─ pify@4.0.1
-│  │  ├─ URL: https://github.com/sindresorhus/pify.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ pify@5.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/pify.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ pirates@4.0.5
-│  │  ├─ URL: https://github.com/danez/pirates.git
-│  │  ├─ VendorName: Ari Porad
-│  │  └─ VendorUrl: https://github.com/danez/pirates#readme
-│  ├─ pkg-dir@3.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/pkg-dir.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ pkg-dir@4.2.0
-│  │  ├─ URL: https://github.com/sindresorhus/pkg-dir.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ pkg-dir@5.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/pkg-dir.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ polished@4.2.2
-│  │  ├─ URL: git+https://github.com/styled-components/polished.git
-│  │  ├─ VendorName: Brian Hough
-│  │  └─ VendorUrl: https://polished.js.org/
-│  ├─ postcss-calc@8.2.4
-│  │  ├─ URL: https://github.com/postcss/postcss-calc.git
-│  │  └─ VendorName: Andy Jansson
-│  ├─ postcss-colormin@5.3.1
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-convert-values@5.1.3
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-discard-comments@5.1.2
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-discard-duplicates@5.1.0
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-discard-empty@5.1.1
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-discard-overridden@5.1.0
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Justineo
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-load-config@3.1.4
-│  │  ├─ URL: https://github.com/postcss/postcss-load-config.git
-│  │  └─ VendorName: Michael Ciniawky
-│  ├─ postcss-merge-longhand@5.1.7
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-merge-rules@5.1.4
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-minify-font-values@5.1.0
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Bogdan Chadkin
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-minify-gradients@5.1.1
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-minify-params@5.1.4
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Bogdan Chadkin
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-minify-selectors@5.2.1
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-modules-local-by-default@4.0.3
-│  │  ├─ URL: https://github.com/css-modules/postcss-modules-local-by-default.git
-│  │  └─ VendorName: Mark Dalgleish
-│  ├─ postcss-modules@4.3.1
-│  │  ├─ URL: https://github.com/css-modules/postcss-modules.git
-│  │  └─ VendorName: Alexander Madyankin
-│  ├─ postcss-normalize-charset@5.1.0
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Bogdan Chadkin
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-normalize-display-values@5.1.0
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-normalize-positions@5.1.1
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-normalize-repeat-style@5.1.1
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-normalize-string@5.1.0
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-normalize-timing-functions@5.1.0
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-normalize-unicode@5.1.1
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-normalize-url@5.1.0
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-normalize-whitespace@5.1.1
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-ordered-values@5.1.3
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-reduce-initial@5.1.2
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-reduce-transforms@5.1.0
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-selector-parser@6.0.13
-│  │  ├─ URL: https://github.com/postcss/postcss-selector-parser.git
-│  │  └─ VendorUrl: https://github.com/postcss/postcss-selector-parser
-│  ├─ postcss-svgo@5.1.0
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-unique-selectors@5.1.1
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-value-parser@4.2.0
-│  │  ├─ URL: https://github.com/TrySound/postcss-value-parser.git
-│  │  ├─ VendorName: Bogdan Chadkin
-│  │  └─ VendorUrl: https://github.com/TrySound/postcss-value-parser
-│  ├─ postcss@8.4.24
-│  │  ├─ URL: https://github.com/postcss/postcss.git
-│  │  ├─ VendorName: Andrey Sitnik
-│  │  └─ VendorUrl: https://postcss.org/
-│  ├─ prelude-ls@1.1.2
-│  │  ├─ URL: git://github.com/gkz/prelude-ls.git
-│  │  ├─ VendorName: George Zahariev
-│  │  └─ VendorUrl: http://preludels.com/
-│  ├─ prelude-ls@1.2.1
-│  │  ├─ URL: git://github.com/gkz/prelude-ls.git
-│  │  ├─ VendorName: George Zahariev
-│  │  └─ VendorUrl: http://preludels.com/
-│  ├─ prettier@2.8.7
-│  │  ├─ URL: https://github.com/prettier/prettier.git
-│  │  ├─ VendorName: James Long
-│  │  └─ VendorUrl: https://prettier.io/
-│  ├─ prettier@2.8.8
-│  │  ├─ URL: https://github.com/prettier/prettier.git
-│  │  ├─ VendorName: James Long
-│  │  └─ VendorUrl: https://prettier.io/
-│  ├─ pretty-error@4.0.0
-│  │  ├─ URL: https://github.com/AriaMinaei/pretty-error.git
-│  │  └─ VendorName: Aria Minaei
-│  ├─ pretty-format@27.5.1
-│  │  ├─ URL: https://github.com/facebook/jest.git
-│  │  └─ VendorName: James Kyle
-│  ├─ pretty-format@28.1.3
-│  │  ├─ URL: https://github.com/facebook/jest.git
-│  │  └─ VendorName: James Kyle
-│  ├─ pretty-format@29.5.0
-│  │  ├─ URL: https://github.com/facebook/jest.git
-│  │  └─ VendorName: James Kyle
-│  ├─ pretty-hrtime@1.0.3
-│  │  ├─ URL: git://github.com/robrich/pretty-hrtime.git
-│  │  ├─ VendorName: Rob Richardson
-│  │  └─ VendorUrl: https://github.com/robrich/pretty-hrtime
-│  ├─ process-nextick-args@2.0.1
-│  │  ├─ URL: https://github.com/calvinmetcalf/process-nextick-args.git
-│  │  └─ VendorUrl: https://github.com/calvinmetcalf/process-nextick-args
-│  ├─ process@0.11.10
-│  │  ├─ URL: git://github.com/shtylman/node-process.git
-│  │  └─ VendorName: Roman Shtylman
-│  ├─ progress@2.0.3
-│  │  ├─ URL: git://github.com/visionmedia/node-progress
-│  │  └─ VendorName: TJ Holowaychuk
-│  ├─ promise.series@0.2.0
-│  │  ├─ URL: https://github.com/egoist/promise.series.git
-│  │  ├─ VendorName: EGOIST
-│  │  └─ VendorUrl: github.com/egoist
-│  ├─ prompts@2.4.2
-│  │  ├─ URL: https://github.com/terkelg/prompts.git
-│  │  ├─ VendorName: Terkel Gjervig
-│  │  └─ VendorUrl: https://terkel.com
-│  ├─ prop-types@15.8.1
-│  │  ├─ URL: https://github.com/facebook/prop-types.git
-│  │  └─ VendorUrl: https://facebook.github.io/react/
-│  ├─ proxy-addr@2.0.7
-│  │  ├─ URL: https://github.com/jshttp/proxy-addr.git
-│  │  └─ VendorName: Douglas Christopher Wilson
-│  ├─ proxy-from-env@1.1.0
-│  │  ├─ URL: https://github.com/Rob--W/proxy-from-env.git
-│  │  ├─ VendorName: Rob Wu
-│  │  └─ VendorUrl: https://github.com/Rob--W/proxy-from-env#readme
-│  ├─ psl@1.9.0
-│  │  ├─ URL: git@github.com:lupomontero/psl.git
-│  │  ├─ VendorName: Lupo Montero
-│  │  └─ VendorUrl: https://lupomontero.com/
-│  ├─ pump@2.0.1
-│  │  ├─ URL: git://github.com/mafintosh/pump.git
-│  │  └─ VendorName: Mathias Buus Madsen
-│  ├─ pump@3.0.0
-│  │  ├─ URL: git://github.com/mafintosh/pump.git
-│  │  └─ VendorName: Mathias Buus Madsen
-│  ├─ pumpify@1.5.1
-│  │  ├─ URL: git://github.com/mafintosh/pumpify
-│  │  ├─ VendorName: Mathias Buus
-│  │  └─ VendorUrl: https://github.com/mafintosh/pumpify
-│  ├─ punycode@2.3.0
-│  │  ├─ URL: https://github.com/mathiasbynens/punycode.js.git
-│  │  ├─ VendorName: Mathias Bynens
-│  │  └─ VendorUrl: https://mths.be/punycode
-│  ├─ querystringify@2.2.0
-│  │  ├─ URL: https://github.com/unshiftio/querystringify
-│  │  ├─ VendorName: Arnout Kazemier
-│  │  └─ VendorUrl: https://github.com/unshiftio/querystringify
-│  ├─ queue-microtask@1.2.3
-│  │  ├─ URL: git://github.com/feross/queue-microtask.git
-│  │  ├─ VendorName: Feross Aboukhadijeh
-│  │  └─ VendorUrl: https://github.com/feross/queue-microtask
-│  ├─ ramda@0.29.0
-│  │  ├─ URL: git://github.com/ramda/ramda.git
-│  │  ├─ VendorName: Scott Sauyet
-│  │  └─ VendorUrl: https://ramdajs.com/
-│  ├─ randombytes@2.1.0
-│  │  ├─ URL: git@github.com:crypto-browserify/randombytes.git
-│  │  └─ VendorUrl: https://github.com/crypto-browserify/randombytes
-│  ├─ range-parser@1.2.1
-│  │  ├─ URL: https://github.com/jshttp/range-parser.git
-│  │  ├─ VendorName: TJ Holowaychuk
-│  │  └─ VendorUrl: http://tjholowaychuk.com
-│  ├─ raw-body@2.5.1
-│  │  ├─ URL: https://github.com/stream-utils/raw-body.git
-│  │  ├─ VendorName: Jonathan Ong
-│  │  └─ VendorUrl: http://jongleberry.com
-│  ├─ react-colorful@5.6.1
-│  │  ├─ URL: https://github.com/omgovich/react-colorful.git
-│  │  ├─ VendorName: Vlad Shilov
-│  │  └─ VendorUrl: https://omgovich.github.io/react-colorful
-│  ├─ react-docgen-typescript@2.2.2
-│  │  ├─ URL: https://github.com/styleguidist/react-docgen-typescript.git
-│  │  └─ VendorUrl: https://github.com/styleguidist/react-docgen-typescript/
-│  ├─ react-docgen@5.4.3
-│  │  ├─ URL: git+https://github.com/reactjs/react-docgen.git
-│  │  └─ VendorName: Felix Kling
-│  ├─ react-dom@18.2.0
-│  │  ├─ URL: https://github.com/facebook/react.git
-│  │  └─ VendorUrl: https://reactjs.org/
-│  ├─ react-element-to-jsx-string@15.0.0
-│  │  ├─ URL: https://github.com/algolia/react-element-to-jsx-string.git
-│  │  ├─ VendorName: Algolia, Inc.
-│  │  └─ VendorUrl: https://github.com/algolia
-│  ├─ react-inspector@6.0.2
-│  │  ├─ URL: https://github.com/xyc/react-inspector.git
-│  │  ├─ VendorName: Xiaoyi Chen
-│  │  └─ VendorUrl: https://github.com/xyc/react-inspector
-│  ├─ react-is@16.13.1
-│  │  ├─ URL: https://github.com/facebook/react.git
-│  │  └─ VendorUrl: https://reactjs.org/
-│  ├─ react-is@17.0.2
-│  │  ├─ URL: https://github.com/facebook/react.git
-│  │  └─ VendorUrl: https://reactjs.org/
-│  ├─ react-is@18.1.0
-│  │  ├─ URL: https://github.com/facebook/react.git
-│  │  └─ VendorUrl: https://reactjs.org/
-│  ├─ react-is@18.2.0
-│  │  ├─ URL: https://github.com/facebook/react.git
-│  │  └─ VendorUrl: https://reactjs.org/
-│  ├─ react-refresh@0.11.0
-│  │  ├─ URL: https://github.com/facebook/react.git
-│  │  └─ VendorUrl: https://reactjs.org/
-│  ├─ react-slick@0.29.0
-│  │  ├─ URL: https://github.com/akiran/react-slick
-│  │  ├─ VendorName: Kiran Abburi
-│  │  └─ VendorUrl: https://react-slick.neostack.com/
-│  ├─ react@18.2.0
-│  │  ├─ URL: https://github.com/facebook/react.git
-│  │  └─ VendorUrl: https://reactjs.org/
-│  ├─ read-pkg-up@7.0.1
-│  │  ├─ URL: https://github.com/sindresorhus/read-pkg-up.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ read-pkg@5.2.0
-│  │  ├─ URL: https://github.com/sindresorhus/read-pkg.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ readable-stream@2.3.8
-│  │  └─ URL: git://github.com/nodejs/readable-stream
-│  ├─ readable-stream@3.6.2
-│  │  └─ URL: git://github.com/nodejs/readable-stream
-│  ├─ readdirp@3.6.0
-│  │  ├─ URL: git://github.com/paulmillr/readdirp.git
-│  │  ├─ VendorName: Thorsten Lorenz
-│  │  └─ VendorUrl: https://github.com/paulmillr/readdirp
-│  ├─ recast@0.21.5
-│  │  ├─ URL: git://github.com/benjamn/recast.git
-│  │  ├─ VendorName: Ben Newman
-│  │  └─ VendorUrl: http://github.com/benjamn/recast
-│  ├─ recast@0.23.2
-│  │  ├─ URL: git://github.com/benjamn/recast.git
-│  │  ├─ VendorName: Ben Newman
-│  │  └─ VendorUrl: http://github.com/benjamn/recast
-│  ├─ rechoir@0.6.2
-│  │  ├─ URL: git://github.com/tkellen/node-rechoir.git
-│  │  ├─ VendorName: Tyler Kellen
-│  │  └─ VendorUrl: https://github.com/tkellen/node-rechoir
-│  ├─ regenerate-unicode-properties@10.1.0
-│  │  ├─ URL: https://github.com/mathiasbynens/regenerate-unicode-properties.git
-│  │  ├─ VendorName: Mathias Bynens
-│  │  └─ VendorUrl: https://github.com/mathiasbynens/regenerate-unicode-properties
-│  ├─ regenerate@1.4.2
-│  │  ├─ URL: https://github.com/mathiasbynens/regenerate.git
-│  │  ├─ VendorName: Mathias Bynens
-│  │  └─ VendorUrl: https://mths.be/regenerate
-│  ├─ regenerator-runtime@0.13.11
-│  │  ├─ URL: https://github.com/facebook/regenerator/tree/main/packages/runtime
-│  │  └─ VendorName: Ben Newman
-│  ├─ regenerator-transform@0.15.1
-│  │  ├─ URL: https://github.com/facebook/regenerator/tree/main/packages/transform
-│  │  └─ VendorName: Ben Newman
-│  ├─ regexp.prototype.flags@1.5.0
-│  │  ├─ URL: git://github.com/es-shims/RegExp.prototype.flags.git
-│  │  └─ VendorName: Jordan Harband
-│  ├─ regexpp@3.2.0
-│  │  ├─ URL: git+https://github.com/mysticatea/regexpp.git
-│  │  ├─ VendorName: Toru Nagashima
-│  │  └─ VendorUrl: https://github.com/mysticatea/regexpp#readme
-│  ├─ regexpu-core@5.3.2
-│  │  ├─ URL: https://github.com/mathiasbynens/regexpu-core.git
-│  │  ├─ VendorName: Mathias Bynens
-│  │  └─ VendorUrl: https://mths.be/regexpu
-│  ├─ relateurl@0.2.7
-│  │  ├─ URL: git://github.com/stevenvachon/relateurl.git
-│  │  ├─ VendorName: Steven Vachon
-│  │  └─ VendorUrl: https://github.com/stevenvachon/relateurl
-│  ├─ remark-external-links@8.0.0
-│  │  ├─ URL: https://github.com/remarkjs/remark-external-links.git
-│  │  └─ VendorName: Cédric Delpoux
-│  ├─ remark-slug@6.1.0
-│  │  ├─ URL: https://github.com/remarkjs/remark-slug.git
-│  │  ├─ VendorName: Titus Wormer
-│  │  └─ VendorUrl: https://wooorm.com
-│  ├─ remove-accents@0.4.4
-│  │  ├─ URL: https://github.com/tyxla/remove-accents
-│  │  ├─ VendorName: Marin Atanasov
-│  │  └─ VendorUrl: https://github.com/tyxla/remove-accents
-│  ├─ renderkid@3.0.0
-│  │  ├─ URL: https://github.com/AriaMinaei/RenderKid.git
-│  │  └─ VendorName: Aria Minaei
-│  ├─ require-directory@2.1.1
-│  │  ├─ URL: git://github.com/troygoode/node-require-directory.git
-│  │  ├─ VendorName: Troy Goode
-│  │  └─ VendorUrl: https://github.com/troygoode/node-require-directory/
-│  ├─ require-from-string@2.0.2
-│  │  ├─ URL: https://github.com/floatdrop/require-from-string.git
-│  │  ├─ VendorName: Vsevolod Strukchinsky
-│  │  └─ VendorUrl: github.com/floatdrop
-│  ├─ requires-port@1.0.0
-│  │  ├─ URL: https://github.com/unshiftio/requires-port
-│  │  ├─ VendorName: Arnout Kazemier
-│  │  └─ VendorUrl: https://github.com/unshiftio/requires-port
-│  ├─ reselect@4.1.8
-│  │  └─ URL: https://github.com/reduxjs/reselect.git
-│  ├─ resize-observer-polyfill@1.5.1
-│  │  ├─ URL: https://github.com/que-etc/resize-observer-polyfill.git
-│  │  ├─ VendorName: Denis Rul
-│  │  └─ VendorUrl: https://github.com/que-etc/resize-observer-polyfill
-│  ├─ resolve-cwd@3.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/resolve-cwd.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ resolve-from@4.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/resolve-from.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ resolve-from@5.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/resolve-from.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ resolve.exports@1.1.1
-│  │  ├─ URL: https://github.com/lukeed/resolve.exports.git
-│  │  ├─ VendorName: Luke Edwards
-│  │  └─ VendorUrl: https://lukeed.com
-│  ├─ resolve@1.22.2
-│  │  ├─ URL: git://github.com/browserify/resolve.git
-│  │  ├─ VendorName: James Halliday
-│  │  └─ VendorUrl: http://substack.net
-│  ├─ resolve@2.0.0-next.4
-│  │  ├─ URL: git://github.com/browserify/resolve.git
-│  │  ├─ VendorName: James Halliday
-│  │  └─ VendorUrl: http://substack.net
-│  ├─ restore-cursor@3.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/restore-cursor.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ reusify@1.0.4
-│  │  ├─ URL: git+https://github.com/mcollina/reusify.git
-│  │  ├─ VendorName: Matteo Collina
-│  │  └─ VendorUrl: https://github.com/mcollina/reusify#readme
-│  ├─ rfdc@1.3.0
-│  │  ├─ URL: git+https://github.com/davidmarkclements/rfdc.git
-│  │  ├─ VendorName: David Mark Clements
-│  │  └─ VendorUrl: https://github.com/davidmarkclements/rfdc#readme
-│  ├─ rifm@0.12.1
-│  │  ├─ URL: https://github.com/istarkov/rifm.git
-│  │  └─ VendorName: istarkov
-│  ├─ rollup-plugin-import-css@3.2.1
-│  │  ├─ URL: git+https://github.com/jleeson/rollup-plugin-import-css.git
-│  │  ├─ VendorName: Jacob Leeson
-│  │  └─ VendorUrl: https://github.com/jleeson/rollup-plugin-import-css#readme
-│  ├─ rollup-plugin-postcss@4.0.2
-│  │  ├─ URL: git+https://github.com/egoist/rollup-plugin-postcss.git
-│  │  ├─ VendorName: EGOIST
-│  │  └─ VendorUrl: https://github.com/egoist/rollup-plugin-postcss#readme
-│  ├─ rollup-plugin-svg@2.0.0
-│  │  ├─ URL: git+https://github.com/antony/rollup-plugin-svg.git
-│  │  ├─ VendorName: Antony Jones
-│  │  └─ VendorUrl: https://github.com/antony/rollup-plugin-svg#readme
-│  ├─ rollup-pluginutils@1.5.2
-│  │  ├─ URL: git+https://github.com/rollup/rollup-pluginutils.git
-│  │  ├─ VendorName: Rich Harris
-│  │  └─ VendorUrl: https://github.com/rollup/rollup-pluginutils#readme
-│  ├─ rollup-pluginutils@2.8.2
-│  │  ├─ URL: https://github.com/rollup/rollup-pluginutils.git
-│  │  ├─ VendorName: Rich Harris
-│  │  └─ VendorUrl: https://github.com/rollup/rollup-pluginutils#readme
-│  ├─ rollup@2.79.1
-│  │  ├─ URL: https://github.com/rollup/rollup.git
-│  │  ├─ VendorName: Rich Harris
-│  │  └─ VendorUrl: https://rollupjs.org/
-│  ├─ run-parallel@1.2.0
-│  │  ├─ URL: git://github.com/feross/run-parallel.git
-│  │  ├─ VendorName: Feross Aboukhadijeh
-│  │  └─ VendorUrl: https://github.com/feross/run-parallel
-│  ├─ safe-buffer@5.1.1
-│  │  ├─ URL: git://github.com/feross/safe-buffer.git
-│  │  ├─ VendorName: Feross Aboukhadijeh
-│  │  └─ VendorUrl: https://github.com/feross/safe-buffer
-│  ├─ safe-buffer@5.1.2
-│  │  ├─ URL: git://github.com/feross/safe-buffer.git
-│  │  ├─ VendorName: Feross Aboukhadijeh
-│  │  └─ VendorUrl: https://github.com/feross/safe-buffer
-│  ├─ safe-buffer@5.2.1
-│  │  ├─ URL: git://github.com/feross/safe-buffer.git
-│  │  ├─ VendorName: Feross Aboukhadijeh
-│  │  └─ VendorUrl: https://github.com/feross/safe-buffer
-│  ├─ safe-regex-test@1.0.0
-│  │  ├─ URL: git+https://github.com/ljharb/safe-regex-test.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/ljharb/safe-regex-test#readme
-│  ├─ safer-buffer@2.1.2
-│  │  ├─ URL: git+https://github.com/ChALkeR/safer-buffer.git
-│  │  ├─ VendorName: Nikita Skovoroda
-│  │  └─ VendorUrl: https://github.com/ChALkeR
-│  ├─ sass-loader@12.6.0
-│  │  ├─ URL: https://github.com/webpack-contrib/sass-loader.git
-│  │  ├─ VendorName: J. Tangelder
-│  │  └─ VendorUrl: https://github.com/webpack-contrib/sass-loader
-│  ├─ sass@1.63.4
-│  │  ├─ URL: https://github.com/sass/dart-sass
-│  │  ├─ VendorName: Natalie Weizenbaum
-│  │  └─ VendorUrl: https://github.com/sass/dart-sass
-│  ├─ scheduler@0.23.0
-│  │  ├─ URL: https://github.com/facebook/react.git
-│  │  └─ VendorUrl: https://reactjs.org/
-│  ├─ schema-utils@2.7.1
-│  │  ├─ URL: https://github.com/webpack/schema-utils.git
-│  │  ├─ VendorName: webpack Contrib
-│  │  └─ VendorUrl: https://github.com/webpack/schema-utils
-│  ├─ schema-utils@3.3.0
-│  │  ├─ URL: https://github.com/webpack/schema-utils.git
-│  │  ├─ VendorName: webpack Contrib
-│  │  └─ VendorUrl: https://github.com/webpack/schema-utils
-│  ├─ schema-utils@4.2.0
-│  │  ├─ URL: https://github.com/webpack/schema-utils.git
-│  │  ├─ VendorName: webpack Contrib
-│  │  └─ VendorUrl: https://github.com/webpack/schema-utils
-│  ├─ send@0.18.0
-│  │  ├─ URL: https://github.com/pillarjs/send.git
-│  │  └─ VendorName: TJ Holowaychuk
-│  ├─ serve-favicon@2.5.0
-│  │  ├─ URL: https://github.com/expressjs/serve-favicon.git
-│  │  └─ VendorName: Douglas Christopher Wilson
-│  ├─ serve-static@1.15.0
-│  │  ├─ URL: https://github.com/expressjs/serve-static.git
-│  │  └─ VendorName: Douglas Christopher Wilson
-│  ├─ shallow-clone@3.0.1
-│  │  ├─ URL: https://github.com/jonschlinkert/shallow-clone.git
-│  │  ├─ VendorName: Jon Schlinkert
-│  │  └─ VendorUrl: https://github.com/jonschlinkert/shallow-clone
-│  ├─ shebang-command@2.0.0
-│  │  ├─ URL: https://github.com/kevva/shebang-command.git
-│  │  ├─ VendorName: Kevin Mårtensson
-│  │  └─ VendorUrl: github.com/kevva
-│  ├─ shebang-regex@3.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/shebang-regex.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ side-channel@1.0.4
-│  │  ├─ URL: git+https://github.com/ljharb/side-channel.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/ljharb/side-channel#readme
-│  ├─ simple-update-notifier@1.1.0
-│  │  ├─ URL: https://github.com/alexbrazier/simple-update-notifier.git
-│  │  ├─ VendorName: alexbrazier
-│  │  └─ VendorUrl: https://github.com/alexbrazier/simple-update-notifier.git
-│  ├─ sisteransi@1.0.5
-│  │  ├─ URL: https://github.com/terkelg/sisteransi
-│  │  ├─ VendorName: Terkel Gjervig
-│  │  └─ VendorUrl: https://terkel.com
-│  ├─ slash@3.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/slash.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ slice-ansi@3.0.0
-│  │  └─ URL: https://github.com/chalk/slice-ansi.git
-│  ├─ slice-ansi@4.0.0
-│  │  └─ URL: https://github.com/chalk/slice-ansi.git
-│  ├─ slice-ansi@5.0.0
-│  │  └─ URL: https://github.com/chalk/slice-ansi.git
-│  ├─ slick-carousel@1.8.1
-│  │  ├─ URL: https://github.com/kenwheeler/slick.git
-│  │  └─ VendorName: Ken Wheeler
-│  ├─ source-map-support@0.5.13
-│  │  └─ URL: https://github.com/evanw/node-source-map-support
-│  ├─ source-map-support@0.5.21
-│  │  └─ URL: https://github.com/evanw/node-source-map-support
-│  ├─ space-separated-tokens@1.1.5
-│  │  ├─ URL: https://github.com/wooorm/space-separated-tokens.git
-│  │  ├─ VendorName: Titus Wormer
-│  │  └─ VendorUrl: https://wooorm.com
-│  ├─ spdx-expression-parse@3.0.1
-│  │  ├─ URL: https://github.com/jslicense/spdx-expression-parse.js.git
-│  │  ├─ VendorName: Kyle E. Mitchell
-│  │  └─ VendorUrl: https://kemitchell.com
-│  ├─ stable@0.1.8
-│  │  ├─ URL: https://github.com/Two-Screen/stable.git
-│  │  └─ VendorName: Angry Bytes
-│  ├─ stack-utils@2.0.6
-│  │  ├─ URL: https://github.com/tapjs/stack-utils.git
-│  │  ├─ VendorName: James Talmage
-│  │  └─ VendorUrl: github.com/jamestalmage
-│  ├─ stackframe@1.3.4
-│  │  ├─ URL: git://github.com/stacktracejs/stackframe.git
-│  │  └─ VendorUrl: https://www.stacktracejs.com/
-│  ├─ statuses@2.0.1
-│  │  └─ URL: https://github.com/jshttp/statuses.git
-│  ├─ stop-iteration-iterator@1.0.0
-│  │  ├─ URL: git+https://github.com/ljharb/stop-iteration-iterator.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/ljharb/stop-iteration-iterator#readme
-│  ├─ storybook@7.0.21
-│  │  ├─ URL: https://github.com/storybookjs/storybook.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/storybook/tree/next/code/lib/cli
-│  ├─ stream-shift@1.0.1
-│  │  ├─ URL: https://github.com/mafintosh/stream-shift.git
-│  │  ├─ VendorName: Mathias Buus
-│  │  └─ VendorUrl: https://github.com/mafintosh/stream-shift
-│  ├─ string_decoder@1.1.1
-│  │  ├─ URL: git://github.com/nodejs/string_decoder.git
-│  │  └─ VendorUrl: https://github.com/nodejs/string_decoder
-│  ├─ string_decoder@1.3.0
-│  │  ├─ URL: git://github.com/nodejs/string_decoder.git
-│  │  └─ VendorUrl: https://github.com/nodejs/string_decoder
-│  ├─ string-argv@0.3.2
-│  │  ├─ URL: https://github.com/mccormicka/string-argv
-│  │  ├─ VendorName: Anthony McCormick
-│  │  └─ VendorUrl: https://github.com/mccormicka/string-argv
-│  ├─ string-convert@0.2.1
-│  │  └─ URL: https://github.com/akiran/string-convert
-│  ├─ string-length@4.0.2
-│  │  ├─ URL: https://github.com/sindresorhus/string-length.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ string-width@4.2.3
-│  │  ├─ URL: https://github.com/sindresorhus/string-width.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ string-width@5.1.2
-│  │  ├─ URL: https://github.com/sindresorhus/string-width.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ string.prototype.matchall@4.0.8
-│  │  ├─ URL: git+https://github.com/es-shims/String.prototype.matchAll.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/es-shims/String.prototype.matchAll#readme
-│  ├─ string.prototype.trim@1.2.7
-│  │  ├─ URL: git://github.com/es-shims/String.prototype.trim.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: http://ljharb.codes
-│  ├─ string.prototype.trimend@1.0.6
-│  │  ├─ URL: git://github.com/es-shims/String.prototype.trimEnd.git
-│  │  └─ VendorName: Jordan Harband
-│  ├─ string.prototype.trimstart@1.0.6
-│  │  ├─ URL: git://github.com/es-shims/String.prototype.trimStart.git
-│  │  └─ VendorName: Jordan Harband
-│  ├─ strip-ansi@6.0.1
-│  │  ├─ URL: https://github.com/chalk/strip-ansi.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ strip-ansi@7.1.0
-│  │  ├─ URL: https://github.com/chalk/strip-ansi.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ strip-bom@3.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/strip-bom.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ strip-bom@4.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/strip-bom.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ strip-final-newline@2.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/strip-final-newline.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ strip-final-newline@3.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/strip-final-newline.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ strip-indent@3.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/strip-indent.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ strip-json-comments@3.1.1
-│  │  ├─ URL: https://github.com/sindresorhus/strip-json-comments.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ style-inject@0.3.0
-│  │  ├─ URL: git+https://github.com/egoist/style-inject.git
-│  │  ├─ VendorName: EGOIST
-│  │  └─ VendorUrl: https://github.com/egoist/style-inject#readme
-│  ├─ style-loader@3.3.3
-│  │  ├─ URL: https://github.com/webpack-contrib/style-loader.git
-│  │  ├─ VendorName: Tobias Koppers @sokra
-│  │  └─ VendorUrl: https://github.com/webpack-contrib/style-loader
-│  ├─ stylehacks@5.1.1
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ stylis@4.2.0
-│  │  ├─ URL: https://github.com/thysultan/stylis.js
-│  │  ├─ VendorName: Sultan Tarimo
-│  │  └─ VendorUrl: https://github.com/thysultan/stylis.js
-│  ├─ supports-color@5.5.0
-│  │  ├─ URL: https://github.com/chalk/supports-color.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ supports-color@7.2.0
-│  │  ├─ URL: https://github.com/chalk/supports-color.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ supports-color@8.1.1
-│  │  ├─ URL: https://github.com/chalk/supports-color.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ supports-hyperlinks@2.3.0
-│  │  ├─ URL: https://github.com/jamestalmage/supports-hyperlinks.git
-│  │  ├─ VendorName: James Talmage
-│  │  └─ VendorUrl: github.com/jamestalmage
-│  ├─ supports-preserve-symlinks-flag@1.0.0
-│  │  ├─ URL: git+https://github.com/inspect-js/node-supports-preserve-symlinks-flag.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/node-supports-preserve-symlinks-flag#readme
-│  ├─ svgo@2.8.0
-│  │  ├─ URL: git://github.com/svg/svgo.git
-│  │  ├─ VendorName: Kir Belevich
-│  │  └─ VendorUrl: https://github.com/svg/svgo
-│  ├─ symbol-tree@3.2.4
-│  │  ├─ URL: https://github.com/jsdom/js-symbol-tree.git
-│  │  ├─ VendorName: Joris van der Wel
-│  │  └─ VendorUrl: https://github.com/jsdom/js-symbol-tree#symbol-tree
-│  ├─ tapable@2.2.1
-│  │  ├─ URL: http://github.com/webpack/tapable.git
-│  │  ├─ VendorName: Tobias Koppers @sokra
-│  │  └─ VendorUrl: https://github.com/webpack/tapable
-│  ├─ tar-fs@2.1.1
-│  │  ├─ URL: https://github.com/mafintosh/tar-fs.git
-│  │  ├─ VendorName: Mathias Buus
-│  │  └─ VendorUrl: https://github.com/mafintosh/tar-fs
-│  ├─ tar-stream@2.2.0
-│  │  ├─ URL: git+https://github.com/mafintosh/tar-stream.git
-│  │  ├─ VendorName: Mathias Buus
-│  │  └─ VendorUrl: https://github.com/mafintosh/tar-stream
-│  ├─ telejson@7.1.0
-│  │  ├─ URL: https://github.com/storybookjs/telejson.git
-│  │  └─ VendorUrl: https://github.com/storybookjs/telejson
-│  ├─ temp-dir@2.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/temp-dir.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ temp@0.8.4
-│  │  ├─ URL: git://github.com/bruce/node-temp.git
-│  │  └─ VendorName: Bruce Williams
-│  ├─ tempy@1.0.1
-│  │  ├─ URL: https://github.com/sindresorhus/tempy.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ terminal-link@2.1.1
-│  │  ├─ URL: https://github.com/sindresorhus/terminal-link.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ terser-webpack-plugin@5.3.9
-│  │  ├─ URL: https://github.com/webpack-contrib/terser-webpack-plugin.git
-│  │  ├─ VendorName: webpack Contrib Team
-│  │  └─ VendorUrl: https://github.com/webpack-contrib/terser-webpack-plugin
-│  ├─ text-table@0.2.0
-│  │  ├─ URL: git://github.com/substack/text-table.git
-│  │  ├─ VendorName: James Halliday
-│  │  └─ VendorUrl: https://github.com/substack/text-table
-│  ├─ through@2.3.8
-│  │  ├─ URL: https://github.com/dominictarr/through.git
-│  │  ├─ VendorName: Dominic Tarr
-│  │  └─ VendorUrl: https://github.com/dominictarr/through
-│  ├─ through2@2.0.5
-│  │  ├─ URL: https://github.com/rvagg/through2.git
-│  │  ├─ VendorName: Rod Vagg
-│  │  └─ VendorUrl: https://github.com/rvagg
-│  ├─ to-fast-properties@2.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/to-fast-properties.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ to-regex-range@5.0.1
-│  │  ├─ URL: https://github.com/micromatch/to-regex-range.git
-│  │  ├─ VendorName: Jon Schlinkert
-│  │  └─ VendorUrl: https://github.com/micromatch/to-regex-range
-│  ├─ toidentifier@1.0.1
-│  │  ├─ URL: https://github.com/component/toidentifier.git
-│  │  └─ VendorName: Douglas Christopher Wilson
-│  ├─ tr46@0.0.3
-│  │  ├─ URL: git+https://github.com/Sebmaster/tr46.js.git
-│  │  ├─ VendorName: Sebastian Mayr
-│  │  └─ VendorUrl: https://github.com/Sebmaster/tr46.js#readme
-│  ├─ tr46@3.0.0
-│  │  ├─ URL: https://github.com/jsdom/tr46
-│  │  └─ VendorName: Sebastian Mayr
-│  ├─ ts-dedent@2.2.0
-│  │  ├─ URL: https://github.com/tamino-martinius/node-ts-dedent.git
-│  │  └─ VendorName: Tamino Martinius
-│  ├─ tsconfig-paths@3.14.2
-│  │  ├─ URL: https://github.com/dividab/tsconfig-paths
-│  │  └─ VendorName: Jonas Kello
-│  ├─ tsutils@3.21.0
-│  │  ├─ URL: https://github.com/ajafff/tsutils
-│  │  └─ VendorName: Klaus Meinhardt
-│  ├─ type-check@0.3.2
-│  │  ├─ URL: git://github.com/gkz/type-check.git
-│  │  ├─ VendorName: George Zahariev
-│  │  └─ VendorUrl: https://github.com/gkz/type-check
-│  ├─ type-check@0.4.0
-│  │  ├─ URL: git://github.com/gkz/type-check.git
-│  │  ├─ VendorName: George Zahariev
-│  │  └─ VendorUrl: https://github.com/gkz/type-check
-│  ├─ type-detect@4.0.8
-│  │  ├─ URL: git+ssh://git@github.com/chaijs/type-detect.git
-│  │  ├─ VendorName: Jake Luer
-│  │  └─ VendorUrl: http://alogicalparadox.com
-│  ├─ type-is@1.6.18
-│  │  └─ URL: https://github.com/jshttp/type-is.git
-│  ├─ typed-array-length@1.0.4
-│  │  ├─ URL: git+https://github.com/inspect-js/typed-array-length.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/typed-array-length#readme
-│  ├─ typedarray-to-buffer@3.1.5
-│  │  ├─ URL: git://github.com/feross/typedarray-to-buffer.git
-│  │  ├─ VendorName: Feross Aboukhadijeh
-│  │  └─ VendorUrl: http://feross.org/
-│  ├─ typedarray@0.0.6
-│  │  ├─ URL: git://github.com/substack/typedarray.git
-│  │  ├─ VendorName: James Halliday
-│  │  └─ VendorUrl: https://github.com/substack/typedarray
-│  ├─ unbox-primitive@1.0.2
-│  │  ├─ URL: git+https://github.com/ljharb/unbox-primitive.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/ljharb/unbox-primitive#readme
-│  ├─ unfetch@4.2.0
-│  │  ├─ URL: https://github.com/developit/unfetch.git
-│  │  └─ VendorUrl: https://github.com/developit/unfetch
-│  ├─ unicode-canonical-property-names-ecmascript@2.0.0
-│  │  ├─ URL: https://github.com/mathiasbynens/unicode-canonical-property-names-ecmascript.git
-│  │  ├─ VendorName: Mathias Bynens
-│  │  └─ VendorUrl: https://github.com/mathiasbynens/unicode-canonical-property-names-ecmascript
-│  ├─ unicode-match-property-ecmascript@2.0.0
-│  │  ├─ URL: https://github.com/mathiasbynens/unicode-match-property-ecmascript.git
-│  │  ├─ VendorName: Mathias Bynens
-│  │  └─ VendorUrl: https://github.com/mathiasbynens/unicode-match-property-ecmascript
-│  ├─ unicode-match-property-value-ecmascript@2.1.0
-│  │  ├─ URL: https://github.com/mathiasbynens/unicode-match-property-value-ecmascript.git
-│  │  ├─ VendorName: Mathias Bynens
-│  │  └─ VendorUrl: https://github.com/mathiasbynens/unicode-match-property-value-ecmascript
-│  ├─ unicode-property-aliases-ecmascript@2.1.0
-│  │  ├─ URL: https://github.com/mathiasbynens/unicode-property-aliases-ecmascript.git
-│  │  ├─ VendorName: Mathias Bynens
-│  │  └─ VendorUrl: https://github.com/mathiasbynens/unicode-property-aliases-ecmascript
-│  ├─ unique-string@2.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/unique-string.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ unist-util-is@4.1.0
-│  │  ├─ URL: https://github.com/syntax-tree/unist-util-is.git
-│  │  ├─ VendorName: Titus Wormer
-│  │  └─ VendorUrl: https://wooorm.com
-│  ├─ unist-util-visit-parents@3.1.1
-│  │  ├─ URL: https://github.com/syntax-tree/unist-util-visit-parents.git
-│  │  ├─ VendorName: Titus Wormer
-│  │  └─ VendorUrl: https://wooorm.com
-│  ├─ unist-util-visit@2.0.3
-│  │  ├─ URL: https://github.com/syntax-tree/unist-util-visit.git
-│  │  ├─ VendorName: Titus Wormer
-│  │  └─ VendorUrl: https://wooorm.com
-│  ├─ universalify@0.2.0
-│  │  ├─ URL: git+https://github.com/RyanZim/universalify.git
-│  │  ├─ VendorName: Ryan Zimmerman
-│  │  └─ VendorUrl: https://github.com/RyanZim/universalify#readme
-│  ├─ universalify@2.0.0
-│  │  ├─ URL: git+https://github.com/RyanZim/universalify.git
-│  │  ├─ VendorName: Ryan Zimmerman
-│  │  └─ VendorUrl: https://github.com/RyanZim/universalify#readme
-│  ├─ unpipe@1.0.0
-│  │  ├─ URL: https://github.com/stream-utils/unpipe.git
-│  │  └─ VendorName: Douglas Christopher Wilson
-│  ├─ unplugin@0.10.2
-│  │  └─ URL: https://github.com/unjs/unplugin.git
-│  ├─ untildify@4.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/untildify.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ update-browserslist-db@1.0.11
-│  │  ├─ URL: https://github.com/browserslist/update-db.git
-│  │  └─ VendorName: Andrey Sitnik
-│  ├─ url-parse@1.5.10
-│  │  ├─ URL: https://github.com/unshiftio/url-parse.git
-│  │  └─ VendorName: Arnout Kazemier
-│  ├─ use-resize-observer@9.1.0
-│  │  ├─ URL: git@github.com:ZeeCoder/use-resize-observer.git
-│  │  └─ VendorName: Viktor Hubert
-│  ├─ util-deprecate@1.0.2
-│  │  ├─ URL: git://github.com/TooTallNate/util-deprecate.git
-│  │  ├─ VendorName: Nathan Rajlich
-│  │  └─ VendorUrl: https://github.com/TooTallNate/util-deprecate
-│  ├─ util@0.12.5
-│  │  ├─ URL: git://github.com/browserify/node-util
-│  │  ├─ VendorName: Joyent
-│  │  └─ VendorUrl: https://github.com/browserify/node-util
-│  ├─ utila@0.4.0
-│  │  ├─ URL: https://github.com/AriaMinaei/utila.git
-│  │  └─ VendorName: Aria Minaei
-│  ├─ utils-merge@1.0.1
-│  │  ├─ URL: git://github.com/jaredhanson/utils-merge.git
-│  │  ├─ VendorName: Jared Hanson
-│  │  └─ VendorUrl: http://www.jaredhanson.net/
-│  ├─ uuid@9.0.0
-│  │  └─ URL: https://github.com/uuidjs/uuid.git
-│  ├─ vary@1.1.2
-│  │  ├─ URL: https://github.com/jshttp/vary.git
-│  │  └─ VendorName: Douglas Christopher Wilson
-│  ├─ w3c-xmlserializer@4.0.0
-│  │  └─ URL: https://github.com/jsdom/w3c-xmlserializer.git
-│  ├─ watchpack@2.4.0
-│  │  ├─ URL: https://github.com/webpack/watchpack.git
-│  │  ├─ VendorName: Tobias Koppers @sokra
-│  │  └─ VendorUrl: https://github.com/webpack/watchpack
-│  ├─ wcwidth@1.0.1
-│  │  ├─ URL: git+https://github.com/timoxley/wcwidth.git
-│  │  ├─ VendorName: Tim Oxley
-│  │  └─ VendorUrl: https://github.com/timoxley/wcwidth#readme
-│  ├─ webpack-dev-middleware@5.3.3
-│  │  ├─ URL: https://github.com/webpack/webpack-dev-middleware.git
-│  │  ├─ VendorName: Tobias Koppers @sokra
-│  │  └─ VendorUrl: https://github.com/webpack/webpack-dev-middleware
-│  ├─ webpack-hot-middleware@2.25.3
-│  │  ├─ URL: https://github.com/webpack-contrib/webpack-hot-middleware.git
-│  │  └─ VendorName: Glen Mailer
-│  ├─ webpack-sources@3.2.3
-│  │  ├─ URL: git+https://github.com/webpack/webpack-sources.git
-│  │  ├─ VendorName: Tobias Koppers @sokra
-│  │  └─ VendorUrl: https://github.com/webpack/webpack-sources#readme
-│  ├─ webpack-virtual-modules@0.4.6
-│  │  ├─ URL: git+https://github.com/sysgears/webpack-virtual-modules.git
-│  │  ├─ VendorName: SysGears INC
-│  │  └─ VendorUrl: https://github.com/sysgears/webpack-virtual-modules#readme
-│  ├─ webpack@5.87.0
-│  │  ├─ URL: https://github.com/webpack/webpack.git
-│  │  ├─ VendorName: Tobias Koppers @sokra
-│  │  └─ VendorUrl: https://github.com/webpack/webpack
-│  ├─ whatwg-encoding@2.0.0
-│  │  ├─ URL: https://github.com/jsdom/whatwg-encoding.git
-│  │  ├─ VendorName: Domenic Denicola
-│  │  └─ VendorUrl: https://domenic.me/
-│  ├─ whatwg-mimetype@3.0.0
-│  │  ├─ URL: https://github.com/jsdom/whatwg-mimetype.git
-│  │  ├─ VendorName: Domenic Denicola
-│  │  └─ VendorUrl: https://domenic.me/
-│  ├─ whatwg-url@11.0.0
-│  │  ├─ URL: https://github.com/jsdom/whatwg-url.git
-│  │  └─ VendorName: Sebastian Mayr
-│  ├─ whatwg-url@5.0.0
-│  │  ├─ URL: https://github.com/jsdom/whatwg-url.git
-│  │  └─ VendorName: Sebastian Mayr
-│  ├─ which-boxed-primitive@1.0.2
-│  │  ├─ URL: git+https://github.com/inspect-js/which-boxed-primitive.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/which-boxed-primitive#readme
-│  ├─ which-collection@1.0.1
-│  │  ├─ URL: git+https://github.com/inspect-js/which-collection.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/which-collection#readme
-│  ├─ which-typed-array@1.1.9
-│  │  ├─ URL: git://github.com/inspect-js/which-typed-array.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: http://ljharb.codes
-│  ├─ widest-line@3.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/widest-line.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ word-wrap@1.2.3
-│  │  ├─ URL: https://github.com/jonschlinkert/word-wrap.git
-│  │  ├─ VendorName: Jon Schlinkert
-│  │  └─ VendorUrl: https://github.com/jonschlinkert/word-wrap
-│  ├─ wordwrap@1.0.0
-│  │  ├─ URL: git://github.com/substack/node-wordwrap.git
-│  │  ├─ VendorName: James Halliday
-│  │  └─ VendorUrl: http://substack.net
-│  ├─ wrap-ansi@6.2.0
-│  │  ├─ URL: https://github.com/chalk/wrap-ansi.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ wrap-ansi@7.0.0
-│  │  ├─ URL: https://github.com/chalk/wrap-ansi.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ ws@6.2.2
-│  │  ├─ URL: https://github.com/websockets/ws.git
-│  │  ├─ VendorName: Einar Otto Stangvik
-│  │  └─ VendorUrl: https://github.com/websockets/ws
-│  ├─ ws@8.13.0
-│  │  ├─ URL: https://github.com/websockets/ws.git
-│  │  ├─ VendorName: Einar Otto Stangvik
-│  │  └─ VendorUrl: https://github.com/websockets/ws
-│  ├─ xmlchars@2.2.0
-│  │  ├─ URL: https://github.com/lddubeau/xmlchars.git
-│  │  └─ VendorName: Louis-Dominique Dubeau
-│  ├─ xtend@4.0.2
-│  │  ├─ URL: git://github.com/Raynos/xtend.git
-│  │  ├─ VendorName: Raynos
-│  │  └─ VendorUrl: https://github.com/Raynos/xtend
-│  ├─ yargs@16.2.0
-│  │  ├─ URL: https://github.com/yargs/yargs.git
-│  │  └─ VendorUrl: https://yargs.js.org/
-│  ├─ yargs@17.7.2
-│  │  ├─ URL: https://github.com/yargs/yargs.git
-│  │  └─ VendorUrl: https://yargs.js.org/
-│  ├─ yauzl@2.10.0
-│  │  ├─ URL: https://github.com/thejoshwolfe/yauzl.git
-│  │  ├─ VendorName: Josh Wolfe
-│  │  └─ VendorUrl: https://github.com/thejoshwolfe/yauzl
-│  └─ yocto-queue@0.1.0
-│     ├─ URL: https://github.com/sindresorhus/yocto-queue.git
-│     ├─ VendorName: Sindre Sorhus
-│     └─ VendorUrl: https://sindresorhus.com
-├─ Python-2.0
-│  └─ argparse@2.0.1
-│     └─ URL: https://github.com/nodeca/argparse.git
-└─ Unlicense
-   ├─ big-integer@1.6.51
-   │  ├─ URL: git@github.com:peterolson/BigInteger.js.git
-   │  └─ VendorName: Peter Olson
-   ├─ fs-monkey@1.0.4
-   │  └─ URL: https://github.com/streamich/fs-monkey.git
-   └─ memfs@3.5.3
-      └─ URL: https://github.com/streamich/memfs.git
+npm/npmjs/-/abab/2.0.6, BSD-3-Clause, approved, clearlydefined
+npm/npmjs/-/accepts/1.3.8, MIT, approved, clearlydefined
+npm/npmjs/-/acorn-globals/7.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/acorn-import-assertions/1.9.0, MIT, approved, clearlydefined
+npm/npmjs/-/acorn-jsx/5.3.2, MIT, approved, clearlydefined
+npm/npmjs/-/acorn-walk/7.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/acorn-walk/8.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/acorn/7.4.1, MIT, approved, clearlydefined
+npm/npmjs/-/acorn/8.8.2, MIT, approved, #6951
+npm/npmjs/-/address/1.2.2, MIT, approved, clearlydefined
+npm/npmjs/-/agent-base/5.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/agent-base/6.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/aggregate-error/3.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/ajv-formats/2.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/ajv-keywords/3.5.2, MIT, approved, clearlydefined
+npm/npmjs/-/ajv-keywords/5.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/ajv/6.12.6, MIT, approved, #979
+npm/npmjs/-/ajv/8.12.0, MIT AND OFL-1.1 AND (EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0), approved, #6025
+npm/npmjs/-/ansi-align/3.0.1, ISC, approved, clearlydefined
+npm/npmjs/-/ansi-escapes/4.3.2, MIT, approved, clearlydefined
+npm/npmjs/-/ansi-html-community/0.0.8, Apache-2.0, approved, clearlydefined
+npm/npmjs/-/ansi-regex/5.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/ansi-regex/6.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/ansi-styles/3.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/ansi-styles/4.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/ansi-styles/5.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/ansi-styles/6.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/anymatch/3.1.3, ISC, approved, #5050
+npm/npmjs/-/app-root-dir/1.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/aproba/2.0.0, ISC, approved, clearlydefined
+npm/npmjs/-/are-we-there-yet/2.0.0, ISC, approved, clearlydefined
+npm/npmjs/-/argparse/1.0.10, MIT, approved, #2174
+npm/npmjs/-/argparse/2.0.1, Python-2.0, approved, CQ22954
+npm/npmjs/-/aria-query/5.1.3, Apache-2.0, approved, clearlydefined
+npm/npmjs/-/array-buffer-byte-length/1.0.0, MIT, approved, #7548
+npm/npmjs/-/array-flatten/1.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/array-includes/3.1.6, MIT, approved, #4577
+npm/npmjs/-/array-union/2.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/array.prototype.flat/1.3.1, MIT, approved, #4574
+npm/npmjs/-/array.prototype.flatmap/1.3.1, MIT, approved, #4651
+npm/npmjs/-/array.prototype.tosorted/1.1.1, MIT, approved, #5051
+npm/npmjs/-/assert/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/ast-types/0.14.2, MIT, approved, clearlydefined
+npm/npmjs/-/ast-types/0.15.2, MIT, approved, clearlydefined
+npm/npmjs/-/ast-types/0.16.1, MIT, approved, clearlydefined
+npm/npmjs/-/astral-regex/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/async-limiter/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/async/3.2.4, Apache-2.0 AND MIT, approved, #1553
+npm/npmjs/-/asynckit/0.4.0, MIT, approved, clearlydefined
+npm/npmjs/-/autosuggest-highlight/3.3.4, MIT, approved, clearlydefined
+npm/npmjs/-/available-typed-arrays/1.0.5, MIT, approved, clearlydefined
+npm/npmjs/-/babel-core/7.0.0-bridge.0, MIT, approved, clearlydefined
+npm/npmjs/-/babel-jest/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/babel-jest/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/babel-loader/8.3.0, MIT, approved, #4618
+npm/npmjs/-/babel-loader/9.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/babel-plugin-add-react-displayname/0.0.5, MIT, approved, clearlydefined
+npm/npmjs/-/babel-plugin-istanbul/6.1.1, BSD-3-Clause, approved, clearlydefined
+npm/npmjs/-/babel-plugin-jest-hoist/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/babel-plugin-jest-hoist/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/babel-plugin-macros/3.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/babel-plugin-named-exports-order/0.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/babel-plugin-polyfill-corejs2/0.3.3, MIT, approved, clearlydefined
+npm/npmjs/-/babel-plugin-polyfill-corejs2/0.4.3, MIT, approved, clearlydefined
+npm/npmjs/-/babel-plugin-polyfill-corejs3/0.6.0, MIT, approved, clearlydefined
+npm/npmjs/-/babel-plugin-polyfill-corejs3/0.8.1, MIT, approved, clearlydefined
+npm/npmjs/-/babel-plugin-polyfill-regenerator/0.4.1, MIT, approved, clearlydefined
+npm/npmjs/-/babel-plugin-polyfill-regenerator/0.5.0, MIT, approved, clearlydefined
+npm/npmjs/-/babel-plugin-react-docgen/4.2.1, MIT AND BSD-3-Clause, approved, #2952
+npm/npmjs/-/babel-preset-current-node-syntax/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/babel-preset-jest/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/babel-preset-jest/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/balanced-match/1.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/base64-js/1.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/better-opn/2.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/big-integer/1.6.51, Unlicense AND MIT, approved, #2439
+npm/npmjs/-/big.js/5.2.2, MIT, approved, clearlydefined
+npm/npmjs/-/binary-extensions/2.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/bl/4.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/body-parser/1.20.1, MIT, approved, clearlydefined
+npm/npmjs/-/boolbase/1.0.0, ISC, approved, clearlydefined
+npm/npmjs/-/boxen/5.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/bplist-parser/0.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/brace-expansion/1.1.11, MIT, approved, clearlydefined
+npm/npmjs/-/brace-expansion/2.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/braces/3.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/browser-assert/1.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/browserify-zlib/0.1.4, MIT, approved, clearlydefined
+npm/npmjs/-/browserslist/4.21.8, MIT, approved, #7034
+npm/npmjs/-/bser/2.1.1, Apache-2.0, approved, clearlydefined
+npm/npmjs/-/buffer-crc32/0.2.13, MIT, approved, clearlydefined
+npm/npmjs/-/buffer-from/1.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/buffer/5.7.1, MIT, approved, clearlydefined
+npm/npmjs/-/builtin-modules/3.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/builtins/5.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/bytes/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/bytes/3.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/c8/7.14.0, ISC AND MIT, approved, #9010
+npm/npmjs/-/call-bind/1.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/callsites/3.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/camel-case/4.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/camelcase/5.3.1, MIT, approved, clearlydefined
+npm/npmjs/-/camelcase/6.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/caniuse-api/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/caniuse-lite/1.0.30001503, CC-BY-4.0, approved, #1196
+npm/npmjs/-/case-sensitive-paths-webpack-plugin/2.4.0, MIT, approved, clearlydefined
+npm/npmjs/-/chalk/2.4.2, MIT, approved, clearlydefined
+npm/npmjs/-/chalk/4.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/chalk/5.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/char-regex/1.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/chokidar/3.5.3, MIT, approved, #2317
+npm/npmjs/-/chownr/1.1.4, ISC, approved, clearlydefined
+npm/npmjs/-/chownr/2.0.0, ISC, approved, clearlydefined
+npm/npmjs/-/chrome-trace-event/1.0.3, MIT, approved, #2414
+npm/npmjs/-/ci-info/3.8.0, MIT, approved, clearlydefined
+npm/npmjs/-/cjs-module-lexer/1.2.3, MIT, approved, #9069
+npm/npmjs/-/classnames/2.3.2, MIT, approved, clearlydefined
+npm/npmjs/-/clean-css/5.3.2, MIT, approved, clearlydefined
+npm/npmjs/-/clean-stack/2.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/cli-boxes/2.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/cli-cursor/3.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/cli-spinners/2.9.0, MIT, approved, #8249
+npm/npmjs/-/cli-table3/0.6.3, MIT, approved, clearlydefined
+npm/npmjs/-/cli-truncate/2.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/cli-truncate/3.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/cliui/7.0.4, ISC AND Artistic-2.0, approved, #2724
+npm/npmjs/-/cliui/8.0.1, ISC AND Artistic-2.0, approved, #3753
+npm/npmjs/-/clone-deep/4.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/clone/1.0.4, MIT, approved, #2729
+npm/npmjs/-/clsx/1.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/co/4.6.0, MIT, approved, clearlydefined
+npm/npmjs/-/collect-v8-coverage/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/color-convert/1.9.3, MIT, approved, clearlydefined
+npm/npmjs/-/color-convert/2.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/color-name/1.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/color-name/1.1.4, MIT, approved, clearlydefined
+npm/npmjs/-/color-support/1.1.3, ISC, approved, clearlydefined
+npm/npmjs/-/colord/2.9.3, MIT, approved, clearlydefined
+npm/npmjs/-/colorette/2.0.20, MIT, approved, clearlydefined
+npm/npmjs/-/combined-stream/1.0.8, MIT, approved, clearlydefined
+npm/npmjs/-/commander/10.0.1, MIT, approved, #8062
+npm/npmjs/-/commander/2.20.3, MIT, approved, clearlydefined
+npm/npmjs/-/commander/6.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/commander/7.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/commander/8.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/common-path-prefix/3.0.0, ISC, approved, clearlydefined
+npm/npmjs/-/commondir/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/compressible/2.0.18, MIT, approved, clearlydefined
+npm/npmjs/-/compression/1.7.4, MIT, approved, #1975
+npm/npmjs/-/concat-map/0.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/concat-stream/1.6.2, MIT, approved, clearlydefined
+npm/npmjs/-/concat-with-sourcemaps/1.1.0, ISC, approved, clearlydefined
+npm/npmjs/-/console-control-strings/1.1.0, ISC, approved, clearlydefined
+npm/npmjs/-/content-disposition/0.5.4, MIT, approved, clearlydefined
+npm/npmjs/-/content-type/1.0.5, MIT, approved, #6950
+npm/npmjs/-/convert-source-map/1.9.0, MIT, approved, clearlydefined
+npm/npmjs/-/convert-source-map/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/cookie-signature/1.0.6, MIT, approved, clearlydefined
+npm/npmjs/-/cookie/0.5.0, MIT, approved, clearlydefined
+npm/npmjs/-/core-js-compat/3.31.0, MIT, approved, #9051
+npm/npmjs/-/core-js-pure/3.31.0, MIT, approved, #8969
+npm/npmjs/-/core-util-is/1.0.3, MIT, approved, #5898
+npm/npmjs/-/cosmiconfig/7.1.0, MIT, approved, #4975
+npm/npmjs/-/cross-spawn/7.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/crypto-random-string/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/css-declaration-sorter/6.4.0, ISC, approved, clearlydefined
+npm/npmjs/-/css-loader/6.8.1, MIT AND Apache-2.0, approved, #8759
+npm/npmjs/-/css-select/4.3.0, BSD-2-Clause AND MIT AND (MIT AND MIT-0), approved, #3227
+npm/npmjs/-/css-tree/1.1.3, MIT, approved, #1283
+npm/npmjs/-/css-what/6.1.0, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/cssesc/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/cssnano-preset-default/5.2.14, MIT, approved, clearlydefined
+npm/npmjs/-/cssnano-utils/3.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/cssnano/5.1.15, MIT, approved, clearlydefined
+npm/npmjs/-/csso/4.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/cssom/0.3.8, MIT, approved, clearlydefined
+npm/npmjs/-/cssom/0.5.0, MIT, approved, clearlydefined
+npm/npmjs/-/cssstyle/2.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/csstype/3.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/data-urls/3.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/date-fns/2.30.0, MIT, approved, clearlydefined
+npm/npmjs/-/debug/2.6.9, MIT, approved, clearlydefined
+npm/npmjs/-/debug/3.2.7, MIT, approved, clearlydefined
+npm/npmjs/-/debug/4.3.4, MIT, approved, clearlydefined
+npm/npmjs/-/decimal.js/10.4.3, MIT, approved, clearlydefined
+npm/npmjs/-/dedent/0.7.0, MIT, approved, clearlydefined
+npm/npmjs/-/deep-equal/2.2.1, MIT, approved, #8406
+npm/npmjs/-/deep-is/0.1.4, MIT, approved, #2130
+npm/npmjs/-/deepmerge/4.3.1, MIT, approved, #7032
+npm/npmjs/-/default-browser-id/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/defaults/1.0.4, MIT, approved, clearlydefined
+npm/npmjs/-/define-lazy-prop/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/define-properties/1.2.0, MIT, approved, #7116
+npm/npmjs/-/defu/6.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/del/6.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/delayed-stream/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/delegates/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/depd/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/dequal/2.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/destroy/1.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/detect-indent/6.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/detect-newline/3.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/detect-package-manager/2.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/detect-port/1.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/diff-sequences/28.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/dir-glob/3.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/doctrine/2.1.0, Apache-2.0 AND BSD-2-Clause, approved, #1987
+npm/npmjs/-/doctrine/3.0.0, Apache-2.0 AND BSD-2-Clause, approved, CQ22628
+npm/npmjs/-/dom-accessibility-api/0.5.16, MIT, approved, clearlydefined
+npm/npmjs/-/dom-converter/0.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/dom-helpers/5.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/dom-serializer/1.4.1, MIT, approved, clearlydefined
+npm/npmjs/-/domelementtype/2.3.0, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/domexception/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/domhandler/4.3.1, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/domutils/2.8.0, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/dot-case/3.0.4, MIT, approved, clearlydefined
+npm/npmjs/-/dotenv-expand/10.0.0, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/dotenv/16.1.4, BSD-2-Clause, approved, #8572
+npm/npmjs/-/duplexify/3.7.1, MIT, approved, clearlydefined
+npm/npmjs/-/eastasianwidth/0.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/ee-first/1.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/ejs/3.1.9, Apache-2.0, approved, #1373
+npm/npmjs/-/electron-to-chromium/1.4.431, ISC, approved, #1950
+npm/npmjs/-/emittery/0.10.2, MIT, approved, clearlydefined
+npm/npmjs/-/emoji-regex/8.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/emoji-regex/9.2.2, MIT, approved, clearlydefined
+npm/npmjs/-/emojis-list/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/encodeurl/1.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/end-of-stream/1.4.4, MIT, approved, clearlydefined
+npm/npmjs/-/endent/2.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/enhanced-resolve/5.15.0, MIT, approved, #8939
+npm/npmjs/-/enquire.js/2.1.6, MIT, approved, clearlydefined
+npm/npmjs/-/entities/2.2.0, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/entities/4.5.0, BSD-2-Clause, approved, #7910
+npm/npmjs/-/envinfo/7.8.1, MIT, approved, clearlydefined
+npm/npmjs/-/error-ex/1.3.2, MIT, approved, clearlydefined
+npm/npmjs/-/error-stack-parser/2.1.4, MIT, approved, clearlydefined
+npm/npmjs/-/es-abstract/1.21.2, MIT, approved, #6209
+npm/npmjs/-/es-get-iterator/1.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/es-module-lexer/1.3.0, MIT, approved, #8964
+npm/npmjs/-/es-set-tostringtag/2.0.1, MIT, approved, #6218
+npm/npmjs/-/es-shim-unscopables/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/es-to-primitive/1.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/es6-object-assign/1.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/esbuild-plugin-alias/0.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/esbuild-register/3.4.2, MIT, approved, clearlydefined
+npm/npmjs/-/esbuild/0.17.19, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #7537
+npm/npmjs/-/escalade/3.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/escape-html/1.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/escape-string-regexp/1.0.5, MIT, approved, clearlydefined
+npm/npmjs/-/escape-string-regexp/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/escape-string-regexp/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/escodegen/2.0.0, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/eslint-config-prettier/8.8.0, MIT, approved, #7543
+npm/npmjs/-/eslint-config-standard-with-typescript/34.0.1, MIT, approved, #7497
+npm/npmjs/-/eslint-config-standard/17.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/eslint-import-resolver-node/0.3.7, MIT, approved, clearlydefined
+npm/npmjs/-/eslint-module-utils/2.8.0, MIT, approved, #8209
+npm/npmjs/-/eslint-plugin-es/4.1.0, MIT, approved, #5026
+npm/npmjs/-/eslint-plugin-import/2.27.5, MIT, approved, #6937
+npm/npmjs/-/eslint-plugin-n/15.7.0, MIT, approved, #9040
+npm/npmjs/-/eslint-plugin-promise/6.1.1, ISC, approved, clearlydefined
+npm/npmjs/-/eslint-plugin-react-hooks/4.6.0, MIT, approved, clearlydefined
+npm/npmjs/-/eslint-plugin-react/7.32.2, MIT, approved, #7035
+npm/npmjs/-/eslint-scope/5.1.1, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/eslint-scope/7.2.0, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/eslint-utils/2.1.0, MIT, approved, #2498
+npm/npmjs/-/eslint-utils/3.0.0, MIT, approved, #2431
+npm/npmjs/-/eslint-visitor-keys/1.3.0, Apache-2.0, approved, #2501
+npm/npmjs/-/eslint-visitor-keys/2.1.0, Apache-2.0, approved, #2433
+npm/npmjs/-/eslint-visitor-keys/3.4.1, Apache-2.0, approved, #7729
+npm/npmjs/-/eslint/8.37.0, MIT, approved, #7732
+npm/npmjs/-/espree/9.5.2, BSD-2-Clause AND BSD-3-Clause AND MIT AND BSD-2-Clause AND BSD-3-Clause AND MIT AND (BSD-2-Clause AND MIT) AND (BSD-3-Clause AND LGPL-2.0-or-later AND MIT) AND LGPL-2.1-or-later, approved, #7478
+npm/npmjs/-/esprima/4.0.1, BSD-2-Clause, approved, #995
+npm/npmjs/-/esquery/1.5.0, BSD-3-Clause, approved, #7469
+npm/npmjs/-/esrecurse/4.3.0, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/estraverse/4.3.0, BSD-2-Clause, approved, #518
+npm/npmjs/-/estraverse/5.3.0, BSD-2-Clause AND MIT, approved, #1557
+npm/npmjs/-/estree-to-babel/3.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/estree-walker/0.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/estree-walker/0.6.1, MIT, approved, clearlydefined
+npm/npmjs/-/estree-walker/2.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/esutils/2.0.3, BSD-2-Clause AND BSD-3-Clause, approved, #120
+npm/npmjs/-/etag/1.8.1, MIT, approved, clearlydefined
+npm/npmjs/-/eventemitter3/4.0.7, MIT, approved, clearlydefined
+npm/npmjs/-/events/3.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/execa/5.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/execa/7.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/exit/0.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/expect/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/express/4.18.2, MIT, approved, clearlydefined
+npm/npmjs/-/extend/3.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/extract-zip/1.7.0, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/fast-deep-equal/3.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/fast-glob/3.2.12, MIT, approved, clearlydefined
+npm/npmjs/-/fast-json-parse/1.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/fast-json-stable-stringify/2.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/fast-levenshtein/2.0.6, MIT, approved, #2428
+npm/npmjs/-/fastq/1.15.0, ISC, approved, #6021
+npm/npmjs/-/fb-watchman/2.0.2, MIT AND Apache-2.0, approved, #5379
+npm/npmjs/-/fd-slicer/1.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/fetch-retry/5.0.6, MIT, approved, clearlydefined
+npm/npmjs/-/file-entry-cache/6.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/file-system-cache/2.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/filelist/1.0.4, Apache-2.0, approved, clearlydefined
+npm/npmjs/-/fill-range/7.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/finalhandler/1.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/find-cache-dir/2.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/find-cache-dir/3.3.2, MIT, approved, clearlydefined
+npm/npmjs/-/find-root/1.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/find-up/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/find-up/4.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/find-up/5.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/flat-cache/3.0.4, MIT, approved, clearlydefined
+npm/npmjs/-/flatted/3.2.7, ISC AND (ISC AND MIT), approved, #2430
+npm/npmjs/-/flow-parser/0.208.1, MIT, approved, #8947
+npm/npmjs/-/for-each/0.3.3, MIT, approved, clearlydefined
+npm/npmjs/-/foreground-child/2.0.0, ISC, approved, clearlydefined
+npm/npmjs/-/fork-ts-checker-webpack-plugin/7.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/form-data/3.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/form-data/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/forwarded/0.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/fresh/0.5.2, MIT, approved, clearlydefined
+npm/npmjs/-/fs-constants/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/fs-extra/10.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/fs-extra/11.1.1, MIT, approved, #5742
+npm/npmjs/-/fs-minipass/2.1.0, ISC, approved, clearlydefined
+npm/npmjs/-/fs-monkey/1.0.4, Unlicense AND (ISC AND MIT), approved, #2964
+npm/npmjs/-/fs.realpath/1.0.0, ISC, approved, clearlydefined
+npm/npmjs/-/fsevents/2.3.2, MIT, approved, #2967
+npm/npmjs/-/function-bind/1.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/function.prototype.name/1.1.5, MIT, approved, clearlydefined
+npm/npmjs/-/functions-have-names/1.2.3, MIT, approved, clearlydefined
+npm/npmjs/-/gauge/3.0.2, ISC, approved, clearlydefined
+npm/npmjs/-/generic-names/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/gensync/1.0.0-beta.2, MIT, approved, clearlydefined
+npm/npmjs/-/get-caller-file/2.0.5, ISC, approved, clearlydefined
+npm/npmjs/-/get-intrinsic/1.2.1, MIT, approved, #8453
+npm/npmjs/-/get-npm-tarball-url/2.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/get-package-type/0.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/get-port/5.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/get-stream/6.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/get-symbol-description/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/giget/1.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/github-slugger/1.5.0, ISC, approved, clearlydefined
+npm/npmjs/-/glob-parent/5.1.2, ISC, approved, clearlydefined
+npm/npmjs/-/glob-parent/6.0.2, ISC, approved, clearlydefined
+npm/npmjs/-/glob-promise/6.0.3, MIT, approved, #8973
+npm/npmjs/-/glob-to-regexp/0.4.1, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/glob/7.2.3, ISC, approved, clearlydefined
+npm/npmjs/-/glob/8.1.0, ISC AND (ISC AND MIT) AND CC-BY-SA-4.0, approved, #7145
+npm/npmjs/-/globals/11.12.0, MIT, approved, clearlydefined
+npm/npmjs/-/globals/13.20.0, MIT, approved, #6953
+npm/npmjs/-/globalthis/1.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/globby/11.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/gopd/1.0.1, MIT, approved, #4863
+npm/npmjs/-/graceful-fs/4.2.11, ISC, approved, #7413
+npm/npmjs/-/grapheme-splitter/1.0.4, MIT, approved, #1645
+npm/npmjs/-/gunzip-maybe/1.4.2, MIT, approved, clearlydefined
+npm/npmjs/-/handlebars/4.7.7, MIT, approved, clearlydefined
+npm/npmjs/-/harmony-reflect/1.6.2, Apache-2.0 AND MPL-1.1 AND Apache-2.0, approved, #2966
+npm/npmjs/-/has-bigints/1.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/has-flag/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/has-flag/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/has-property-descriptors/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/has-proto/1.0.1, MIT, approved, #6175
+npm/npmjs/-/has-symbols/1.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/has-tostringtag/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/has-unicode/2.0.1, ISC, approved, clearlydefined
+npm/npmjs/-/has/1.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/he/1.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/hoist-non-react-statics/3.3.2, BSD-3-Clause, approved, clearlydefined
+npm/npmjs/-/hosted-git-info/2.8.9, ISC, approved, clearlydefined
+npm/npmjs/-/html-encoding-sniffer/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/html-entities/2.3.6, MIT, approved, #9043
+npm/npmjs/-/html-escaper/2.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/html-minifier-terser/6.1.0, MIT AND MPL-1.1, approved, #2968
+npm/npmjs/-/html-tags/3.3.1, MIT, approved, clearlydefined
+npm/npmjs/-/html-webpack-plugin/5.5.3, MIT, approved, #9078
+npm/npmjs/-/htmlparser2/6.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/http-errors/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/http-proxy-agent/5.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/https-proxy-agent/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/https-proxy-agent/5.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/human-signals/2.1.0, Apache-2.0, approved, clearlydefined
+npm/npmjs/-/human-signals/4.3.1, Apache-2.0, approved, clearlydefined
+npm/npmjs/-/husky/8.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/iconv-lite/0.4.24, MIT, approved, clearlydefined
+npm/npmjs/-/iconv-lite/0.6.3, MIT, approved, clearlydefined
+npm/npmjs/-/icss-replace-symbols/1.1.0, ISC, approved, clearlydefined
+npm/npmjs/-/icss-utils/5.1.0, ISC, approved, clearlydefined
+npm/npmjs/-/identity-obj-proxy/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/ieee754/1.2.1, BSD-3-Clause, approved, clearlydefined
+npm/npmjs/-/ignore/5.2.4, MIT, approved, #5907
+npm/npmjs/-/immutable/4.3.0, MIT, approved, #7353
+npm/npmjs/-/import-cwd/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/import-fresh/3.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/import-from/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/import-local/3.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/imurmurhash/0.1.4, MIT, approved, clearlydefined
+npm/npmjs/-/indent-string/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/inflight/1.0.6, ISC, approved, clearlydefined
+npm/npmjs/-/inherits/2.0.4, ISC, approved, clearlydefined
+npm/npmjs/-/internal-slot/1.0.5, MIT, approved, #7118
+npm/npmjs/-/interpret/1.4.0, MIT, approved, clearlydefined
+npm/npmjs/-/ip/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/ipaddr.js/1.9.1, MIT, approved, clearlydefined
+npm/npmjs/-/is-absolute-url/3.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/is-arguments/1.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/is-array-buffer/3.0.2, MIT, approved, #6248
+npm/npmjs/-/is-arrayish/0.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/is-bigint/1.0.4, MIT, approved, clearlydefined
+npm/npmjs/-/is-binary-path/2.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/is-boolean-object/1.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/is-builtin-module/3.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/is-callable/1.2.7, MIT, approved, clearlydefined
+npm/npmjs/-/is-core-module/2.12.1, MIT, approved, clearlydefined
+npm/npmjs/-/is-date-object/1.0.5, MIT, approved, clearlydefined
+npm/npmjs/-/is-deflate/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/is-docker/2.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/is-extglob/2.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/is-fullwidth-code-point/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/is-fullwidth-code-point/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/is-generator-fn/2.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/is-generator-function/1.0.10, MIT, approved, clearlydefined
+npm/npmjs/-/is-glob/4.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/is-gzip/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/is-interactive/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/is-map/2.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/is-module/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/is-nan/1.3.2, MIT, approved, clearlydefined
+npm/npmjs/-/is-negative-zero/2.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/is-number-object/1.0.7, MIT, approved, clearlydefined
+npm/npmjs/-/is-number/7.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/is-path-cwd/2.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/is-path-inside/3.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/is-plain-object/2.0.4, MIT, approved, clearlydefined
+npm/npmjs/-/is-plain-object/5.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/is-potential-custom-element-name/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/is-reference/1.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/is-regex/1.1.4, MIT, approved, clearlydefined
+npm/npmjs/-/is-set/2.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/is-shared-array-buffer/1.0.2, MIT, approved, #1207
+npm/npmjs/-/is-stream/2.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/is-stream/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/is-string/1.0.7, MIT, approved, clearlydefined
+npm/npmjs/-/is-symbol/1.0.4, MIT, approved, clearlydefined
+npm/npmjs/-/is-typed-array/1.1.10, MIT, approved, #4853
+npm/npmjs/-/is-typedarray/1.0.0, MIT, approved, #2531
+npm/npmjs/-/is-unicode-supported/0.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/is-weakmap/2.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/is-weakref/1.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/is-weakset/2.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/is-wsl/2.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/isarray/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/isarray/2.0.5, MIT, approved, clearlydefined
+npm/npmjs/-/isexe/2.0.0, ISC, approved, clearlydefined
+npm/npmjs/-/isobject/3.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/isomorphic-unfetch/3.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/istanbul-lib-coverage/3.2.0, BSD-3-Clause, approved, clearlydefined
+npm/npmjs/-/istanbul-lib-instrument/5.2.1, BSD-3-Clause, approved, clearlydefined
+npm/npmjs/-/istanbul-lib-report/3.0.0, BSD-3-Clause, approved, clearlydefined
+npm/npmjs/-/istanbul-lib-source-maps/4.0.1, BSD-3-Clause, approved, clearlydefined
+npm/npmjs/-/istanbul-reports/3.1.5, BSD-3-Clause AND MIT, approved, #1710
+npm/npmjs/-/jake/10.8.7, Apache-2.0 AND MIT, approved, #1316
+npm/npmjs/-/jest-changed-files/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/jest-circus/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/jest-cli/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/jest-config/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/jest-diff/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/jest-docblock/28.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/jest-each/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/jest-environment-jsdom/29.5.0, MIT, approved, clearlydefined
+npm/npmjs/-/jest-environment-node/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/jest-get-type/28.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/jest-haste-map/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/jest-haste-map/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/jest-haste-map/29.5.0, MIT, approved, clearlydefined
+npm/npmjs/-/jest-leak-detector/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/jest-matcher-utils/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/jest-message-util/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/jest-message-util/29.5.0, MIT, approved, clearlydefined
+npm/npmjs/-/jest-mock/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/jest-mock/29.5.0, MIT, approved, clearlydefined
+npm/npmjs/-/jest-pnp-resolver/1.2.3, MIT, approved, clearlydefined
+npm/npmjs/-/jest-regex-util/27.5.1, 0BSD AND Apache-2.0 AND BSD-2-Clause AND MIT, approved, #1955
+npm/npmjs/-/jest-regex-util/28.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/jest-regex-util/29.4.3, MIT, approved, clearlydefined
+npm/npmjs/-/jest-resolve-dependencies/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/jest-resolve/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/jest-runner/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/jest-runtime/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/jest-serializer/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/jest-snapshot/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/jest-util/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/jest-util/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/jest-util/29.5.0, MIT, approved, clearlydefined
+npm/npmjs/-/jest-validate/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/jest-watcher/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/jest-worker/27.5.1, 0BSD AND Apache-2.0 AND BSD-2-Clause AND MIT, approved, #1952
+npm/npmjs/-/jest-worker/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/jest-worker/29.5.0, MIT, approved, clearlydefined
+npm/npmjs/-/jest/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/jquery/3.7.0, MIT, approved, clearlydefined
+npm/npmjs/-/js-sdsl/4.4.1, MIT, approved, #7722
+npm/npmjs/-/js-tokens/4.0.0, MIT, approved, #2401
+npm/npmjs/-/js-yaml/3.14.1, MIT, approved, clearlydefined
+npm/npmjs/-/js-yaml/4.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/jscodeshift/0.14.0, MIT, approved, #9032
+npm/npmjs/-/jsdom/20.0.3, MIT AND LGPL-2.0-or-later, approved, #7436
+npm/npmjs/-/jsesc/0.5.0, MIT, approved, clearlydefined
+npm/npmjs/-/jsesc/2.5.2, MIT, approved, clearlydefined
+npm/npmjs/-/json-parse-even-better-errors/2.3.1, MIT, approved, clearlydefined
+npm/npmjs/-/json-schema-traverse/0.4.1, MIT, approved, clearlydefined
+npm/npmjs/-/json-schema-traverse/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/json-stable-stringify-without-jsonify/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/json2mq/0.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/json5/1.0.2, MIT, approved, CQ22351
+npm/npmjs/-/json5/2.2.3, MIT, approved, #2126
+npm/npmjs/-/jsonfile/6.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/jsx-ast-utils/3.3.3, MIT, approved, clearlydefined
+npm/npmjs/-/kind-of/6.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/kleur/3.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/klona/2.0.6, MIT, approved, clearlydefined
+npm/npmjs/-/lazy-universal-dotenv/4.0.0, Apache-2.0, approved, clearlydefined
+npm/npmjs/-/leven/3.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/levn/0.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/levn/0.4.1, MIT, approved, clearlydefined
+npm/npmjs/-/lilconfig/2.1.0, MIT, approved, #7313
+npm/npmjs/-/lines-and-columns/1.2.4, MIT, approved, clearlydefined
+npm/npmjs/-/lint-staged/13.2.2, MIT, approved, clearlydefined
+npm/npmjs/-/listr2/5.0.8, MIT, approved, clearlydefined
+npm/npmjs/-/loader-runner/4.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/loader-utils/2.0.4, MIT, approved, #4986
+npm/npmjs/-/loader-utils/3.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/locate-path/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/locate-path/5.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/locate-path/6.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/lodash.camelcase/4.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/lodash.debounce/4.0.8, MIT, approved, clearlydefined
+npm/npmjs/-/lodash.memoize/4.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/lodash.merge/4.6.2, MIT, approved, clearlydefined
+npm/npmjs/-/lodash.uniq/4.5.0, MIT, approved, clearlydefined
+npm/npmjs/-/lodash/4.17.21, CC0-1.0 AND MIT, approved, #2096
+npm/npmjs/-/log-symbols/4.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/log-update/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/loose-envify/1.4.0, MIT, approved, clearlydefined
+npm/npmjs/-/lower-case/2.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/lru-cache/5.1.1, ISC, approved, clearlydefined
+npm/npmjs/-/lru-cache/6.0.0, ISC, approved, clearlydefined
+npm/npmjs/-/lz-string/1.5.0, MIT AND WTFPL, approved, #8398
+npm/npmjs/-/magic-string/0.27.0, MIT, approved, #5748
+npm/npmjs/-/make-dir/2.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/make-dir/3.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/makeerror/1.0.12, BSD-3-Clause, approved, clearlydefined
+npm/npmjs/-/map-or-similar/1.5.0, MIT, approved, clearlydefined
+npm/npmjs/-/markdown-to-jsx/7.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/mdast-util-definitions/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/mdast-util-to-string/1.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/mdn-data/2.0.14, CC0-1.0, approved, clearlydefined
+npm/npmjs/-/media-typer/0.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/memfs/3.5.3, Unlicense, approved, #8397
+npm/npmjs/-/memoizerific/1.11.3, MIT, approved, clearlydefined
+npm/npmjs/-/merge-descriptors/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/merge-stream/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/merge2/1.4.1, MIT, approved, clearlydefined
+npm/npmjs/-/methods/1.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/micromatch/4.0.5, MIT, approved, clearlydefined
+npm/npmjs/-/mime-db/1.52.0, MIT, approved, clearlydefined
+npm/npmjs/-/mime-types/2.1.35, MIT, approved, clearlydefined
+npm/npmjs/-/mime/1.6.0, MIT, approved, clearlydefined
+npm/npmjs/-/mime/2.6.0, MIT, approved, clearlydefined
+npm/npmjs/-/mimic-fn/2.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/mimic-fn/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/min-indent/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/mini-svg-data-uri/1.4.4, MIT, approved, clearlydefined
+npm/npmjs/-/minimatch/3.1.2, ISC, approved, clearlydefined
+npm/npmjs/-/minimatch/5.1.6, ISC, approved, #5952
+npm/npmjs/-/minimist/1.2.8, MIT, approved, #5886
+npm/npmjs/-/minipass/3.3.6, ISC, approved, clearlydefined
+npm/npmjs/-/minipass/5.0.0, ISC, approved, clearlydefined
+npm/npmjs/-/minizlib/2.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/mkdirp-classic/0.5.3, MIT, approved, clearlydefined
+npm/npmjs/-/mkdirp/0.5.6, MIT, approved, clearlydefined
+npm/npmjs/-/mkdirp/1.0.4, MIT, approved, clearlydefined
+npm/npmjs/-/mri/1.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/ms/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/ms/2.1.1, MIT, approved, #5895
+npm/npmjs/-/ms/2.1.2, MIT, approved, #5895
+npm/npmjs/-/ms/2.1.3, MIT, approved, #5895
+npm/npmjs/-/nanoid/3.3.6, MIT, approved, #7571
+npm/npmjs/-/natural-compare-lite/1.4.0, MIT, approved, clearlydefined
+npm/npmjs/-/natural-compare/1.4.0, MIT, approved, clearlydefined
+npm/npmjs/-/negotiator/0.6.3, MIT, approved, clearlydefined
+npm/npmjs/-/neo-async/2.6.2, MIT, approved, clearlydefined
+npm/npmjs/-/no-case/3.0.4, MIT, approved, clearlydefined
+npm/npmjs/-/node-abort-controller/3.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/node-dir/0.1.17, MIT, approved, #1343
+npm/npmjs/-/node-fetch-native/1.2.0, MIT, approved, #9052
+npm/npmjs/-/node-fetch/2.6.11, MIT, approved, #6954
+npm/npmjs/-/node-int64/0.4.0, MIT, approved, clearlydefined
+npm/npmjs/-/node-releases/2.0.12, MIT, approved, #1954
+npm/npmjs/-/normalize-package-data/2.5.0, BSD-2-Clause AND Apache-2.0 AND MIT, approved, #2499
+npm/npmjs/-/normalize-path/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/normalize-url/6.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/npm-run-path/4.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/npm-run-path/5.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/npmlog/5.0.1, ISC, approved, clearlydefined
+npm/npmjs/-/nth-check/2.1.1, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/nwsapi/2.2.5, MIT, approved, #7909
+npm/npmjs/-/object-assign/4.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/object-inspect/1.12.3, MIT, approved, clearlydefined
+npm/npmjs/-/object-is/1.1.5, MIT, approved, clearlydefined
+npm/npmjs/-/object-keys/1.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/object.assign/4.1.4, MIT, approved, #3232
+npm/npmjs/-/object.entries/1.1.6, MIT, approved, #4671
+npm/npmjs/-/object.fromentries/2.0.6, MIT, approved, #4600
+npm/npmjs/-/object.hasown/1.1.2, MIT, approved, #4667
+npm/npmjs/-/object.values/1.1.6, MIT, approved, #4665
+npm/npmjs/-/objectorarray/1.0.5, ISC AND MIT, approved, clearlydefined
+npm/npmjs/-/on-finished/2.4.1, MIT, approved, clearlydefined
+npm/npmjs/-/on-headers/1.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/once/1.4.0, ISC, approved, clearlydefined
+npm/npmjs/-/onetime/5.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/onetime/6.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/open/7.4.2, MIT, approved, clearlydefined
+npm/npmjs/-/open/8.4.2, MIT, approved, #7102
+npm/npmjs/-/optionator/0.8.3, MIT, approved, clearlydefined
+npm/npmjs/-/optionator/0.9.1, MIT, approved, clearlydefined
+npm/npmjs/-/ora/5.4.1, MIT, approved, clearlydefined
+npm/npmjs/-/p-finally/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/p-limit/2.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/p-limit/3.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/p-locate/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/p-locate/4.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/p-locate/5.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/p-map/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/p-queue/6.6.2, MIT, approved, clearlydefined
+npm/npmjs/-/p-timeout/3.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/p-try/2.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/pako/0.2.9, MIT, approved, clearlydefined
+npm/npmjs/-/param-case/3.0.4, MIT, approved, clearlydefined
+npm/npmjs/-/parent-module/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/parse-json/5.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/parse5/7.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/parseurl/1.3.3, MIT, approved, clearlydefined
+npm/npmjs/-/pascal-case/3.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/path-browserify/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/path-exists/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/path-exists/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/path-is-absolute/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/path-key/3.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/path-key/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/path-parse/1.0.7, MIT, approved, clearlydefined
+npm/npmjs/-/path-to-regexp/0.1.7, MIT, approved, clearlydefined
+npm/npmjs/-/path-type/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/pathe/1.1.1, MIT, approved, #8126
+npm/npmjs/-/peek-stream/1.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/pend/1.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/picocolors/1.0.0, ISC, approved, clearlydefined
+npm/npmjs/-/picomatch/2.3.1, MIT, approved, clearlydefined
+npm/npmjs/-/pidtree/0.6.0, MIT, approved, clearlydefined
+npm/npmjs/-/pify/4.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/pify/5.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/pirates/4.0.5, MIT, approved, #680
+npm/npmjs/-/pkg-dir/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/pkg-dir/4.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/pkg-dir/5.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/polished/4.2.2, MIT AND BSD-3-Clause AND OFL-1.1, approved, #3234
+npm/npmjs/-/postcss-calc/8.2.4, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-colormin/5.3.1, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-convert-values/5.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-discard-comments/5.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-discard-duplicates/5.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-discard-empty/5.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-discard-overridden/5.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-load-config/3.1.4, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-merge-longhand/5.1.7, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-merge-rules/5.1.4, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-minify-font-values/5.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-minify-gradients/5.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-minify-params/5.1.4, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-minify-selectors/5.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-modules-extract-imports/3.0.0, ISC, approved, clearlydefined
+npm/npmjs/-/postcss-modules-local-by-default/4.0.3, MIT, approved, #8508
+npm/npmjs/-/postcss-modules-scope/3.0.0, ISC, approved, clearlydefined
+npm/npmjs/-/postcss-modules-values/4.0.0, ISC, approved, clearlydefined
+npm/npmjs/-/postcss-modules/4.3.1, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-normalize-charset/5.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-normalize-display-values/5.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-normalize-positions/5.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-normalize-repeat-style/5.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-normalize-string/5.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-normalize-timing-functions/5.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-normalize-unicode/5.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-normalize-url/5.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-normalize-whitespace/5.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-ordered-values/5.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-reduce-initial/5.1.2, MIT AND (CC0-1.0 AND MIT) AND CC0-1.0, approved, #2972
+npm/npmjs/-/postcss-reduce-transforms/5.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-selector-parser/6.0.13, MIT, approved, #5056
+npm/npmjs/-/postcss-svgo/5.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-unique-selectors/5.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-value-parser/4.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/postcss/8.4.24, MIT, approved, #3545
+npm/npmjs/-/prelude-ls/1.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/prelude-ls/1.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/prettier/2.8.7, MIT AND (0BSD AND Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND CC-BY-SA-4.0 AND ISC AND MIT) AND BSD-2-Clause, approved, #6871
+npm/npmjs/-/prettier/2.8.8, MIT AND (0BSD AND Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND CC-BY-SA-4.0 AND ISC AND MIT) AND BSD-2-Clause, approved, #6871
+npm/npmjs/-/pretty-error/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/pretty-format/27.5.1, 0BSD AND Apache-2.0 AND BSD-2-Clause AND MIT, approved, #1948
+npm/npmjs/-/pretty-format/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/pretty-format/29.5.0, MIT, approved, clearlydefined
+npm/npmjs/-/pretty-hrtime/1.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/process-nextick-args/2.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/process/0.11.10, MIT, approved, CQ23452
+npm/npmjs/-/progress/2.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/promise.series/0.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/prompts/2.4.2, MIT, approved, clearlydefined
+npm/npmjs/-/prop-types/15.8.1, MIT, approved, clearlydefined
+npm/npmjs/-/proxy-addr/2.0.7, MIT, approved, clearlydefined
+npm/npmjs/-/proxy-from-env/1.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/psl/1.9.0, MIT AND CC0-1.0, approved, #3080
+npm/npmjs/-/pump/2.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/pump/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/pumpify/1.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/punycode/2.3.0, MIT, approved, #6373
+npm/npmjs/-/puppeteer-core/2.1.1, Apache-2.0, approved, clearlydefined
+npm/npmjs/-/qs/6.11.0, BSD-3-Clause, approved, #7556
+npm/npmjs/-/qs/6.11.2, BSD-3-Clause, approved, #7556
+npm/npmjs/-/querystringify/2.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/queue-microtask/1.2.3, MIT, approved, clearlydefined
+npm/npmjs/-/ramda/0.29.0, MIT, approved, #8976
+npm/npmjs/-/randombytes/2.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/range-parser/1.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/raw-body/2.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/react-colorful/5.6.1, MIT, approved, clearlydefined
+npm/npmjs/-/react-docgen-typescript/2.2.2, MIT, approved, clearlydefined
+npm/npmjs/-/react-docgen/5.4.3, MIT, approved, clearlydefined
+npm/npmjs/-/react-dom/18.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/react-element-to-jsx-string/15.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/react-inspector/6.0.2, MIT, approved, #8932
+npm/npmjs/-/react-is/16.13.1, MIT, approved, clearlydefined
+npm/npmjs/-/react-is/17.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/react-is/18.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/react-is/18.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/react-refresh/0.11.0, MIT, approved, clearlydefined
+npm/npmjs/-/react-slick/0.29.0, MIT, approved, clearlydefined
+npm/npmjs/-/react-transition-group/4.4.5, BSD-3-Clause, approved, CQ22955
+npm/npmjs/-/react/18.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/read-pkg-up/7.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/read-pkg/5.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/readable-stream/2.3.8, MIT, approved, #945
+npm/npmjs/-/readable-stream/3.6.2, MIT, approved, CQ22627
+npm/npmjs/-/readdirp/3.6.0, MIT, approved, #2977
+npm/npmjs/-/recast/0.21.5, MIT, approved, clearlydefined
+npm/npmjs/-/recast/0.23.2, MIT, approved, clearlydefined
+npm/npmjs/-/rechoir/0.6.2, MIT, approved, #981
+npm/npmjs/-/regenerate-unicode-properties/10.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/regenerate/1.4.2, MIT, approved, clearlydefined
+npm/npmjs/-/regenerator-runtime/0.13.11, MIT, approved, #4978
+npm/npmjs/-/regenerator-transform/0.15.1, MIT, approved, #5001
+npm/npmjs/-/regexp.prototype.flags/1.5.0, MIT, approved, #8199
+npm/npmjs/-/regexpp/3.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/regexpu-core/5.3.2, MIT, approved, #7117
+npm/npmjs/-/regjsparser/0.9.1, BSD-2-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #3329
+npm/npmjs/-/relateurl/0.2.7, MIT, approved, clearlydefined
+npm/npmjs/-/remark-external-links/8.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/remark-slug/6.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/remove-accents/0.4.4, MIT, approved, clearlydefined
+npm/npmjs/-/renderkid/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/require-directory/2.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/require-from-string/2.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/requires-port/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/reselect/4.1.8, MIT, approved, clearlydefined
+npm/npmjs/-/resize-observer-polyfill/1.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/resolve-cwd/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/resolve-from/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/resolve-from/5.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/resolve.exports/1.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/resolve/1.22.2, MIT AND ISC, approved, #2409
+npm/npmjs/-/resolve/2.0.0-next.4, MIT AND ISC, approved, #3078
+npm/npmjs/-/restore-cursor/3.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/reusify/1.0.4, MIT, approved, clearlydefined
+npm/npmjs/-/rfdc/1.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/rifm/0.12.1, MIT, approved, clearlydefined
+npm/npmjs/-/rimraf/2.6.3, ISC, approved, clearlydefined
+npm/npmjs/-/rimraf/2.7.1, ISC, approved, clearlydefined
+npm/npmjs/-/rimraf/3.0.2, ISC, approved, clearlydefined
+npm/npmjs/-/rollup-plugin-import-css/3.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/rollup-plugin-postcss/4.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/rollup-plugin-svg/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/rollup-pluginutils/1.5.2, MIT, approved, clearlydefined
+npm/npmjs/-/rollup-pluginutils/2.8.2, MIT, approved, clearlydefined
+npm/npmjs/-/rollup/2.79.1, MIT, approved, clearlydefined
+npm/npmjs/-/run-parallel/1.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/rxjs/7.8.1, Apache-2.0 AND (0BSD AND Apache-2.0) AND 0BSD, approved, #5993
+npm/npmjs/-/safe-buffer/5.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/safe-buffer/5.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/safe-buffer/5.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/safe-identifier/0.4.2, ISC, approved, clearlydefined
+npm/npmjs/-/safe-regex-test/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/safer-buffer/2.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/sass-loader/12.6.0, MIT, approved, clearlydefined
+npm/npmjs/-/sass/1.63.4, MIT, approved, #8718
+npm/npmjs/-/saxes/6.0.0, ISC, approved, clearlydefined
+npm/npmjs/-/scheduler/0.23.0, MIT, approved, clearlydefined
+npm/npmjs/-/schema-utils/2.7.1, MIT, approved, clearlydefined
+npm/npmjs/-/schema-utils/3.3.0, MIT, approved, #8952
+npm/npmjs/-/schema-utils/4.2.0, MIT, approved, #8986
+npm/npmjs/-/semver/5.7.1, ISC, approved, #5900
+npm/npmjs/-/semver/6.3.0, ISC, approved, clearlydefined
+npm/npmjs/-/semver/7.0.0, ISC, approved, clearlydefined
+npm/npmjs/-/semver/7.5.1, ISC, approved, clearlydefined
+npm/npmjs/-/send/0.18.0, MIT, approved, clearlydefined
+npm/npmjs/-/serialize-javascript/6.0.1, BSD-3-Clause, approved, clearlydefined
+npm/npmjs/-/serve-favicon/2.5.0, MIT, approved, clearlydefined
+npm/npmjs/-/serve-static/1.15.0, MIT, approved, clearlydefined
+npm/npmjs/-/set-blocking/2.0.0, ISC, approved, #5899
+npm/npmjs/-/setprototypeof/1.2.0, ISC, approved, clearlydefined
+npm/npmjs/-/shallow-clone/3.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/shebang-command/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/shebang-regex/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/shelljs/0.8.5, BSD-3-Clause AND MIT, approved, #1126
+npm/npmjs/-/side-channel/1.0.4, MIT, approved, clearlydefined
+npm/npmjs/-/signal-exit/3.0.7, ISC, approved, #5892
+npm/npmjs/-/simple-update-notifier/1.1.0, MIT AND 0BSD, approved, #8991
+npm/npmjs/-/sisteransi/1.0.5, MIT, approved, clearlydefined
+npm/npmjs/-/slash/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/slice-ansi/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/slice-ansi/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/slice-ansi/5.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/slick-carousel/1.8.1, MIT, approved, #2986
+npm/npmjs/-/source-map-js/1.0.2, BSD-3-Clause, approved, #2412
+npm/npmjs/-/source-map-support/0.5.13, MIT, approved, clearlydefined
+npm/npmjs/-/source-map-support/0.5.21, MIT, approved, clearlydefined
+npm/npmjs/-/source-map/0.5.7, BSD-3-Clause, approved, #2400
+npm/npmjs/-/source-map/0.6.1, BSD-3-Clause, approved, #2417
+npm/npmjs/-/source-map/0.7.4, BSD-3-Clause, approved, #2416
+npm/npmjs/-/space-separated-tokens/1.1.5, MIT, approved, clearlydefined
+npm/npmjs/-/spdx-correct/3.2.0, Apache-2.0, approved, #7493
+npm/npmjs/-/spdx-exceptions/2.3.0, CC-BY-3.0, approved, clearlydefined
+npm/npmjs/-/spdx-expression-parse/3.0.1, MIT, approved, #1127
+npm/npmjs/-/spdx-license-ids/3.0.13, CC0-1.0, approved, #989
+npm/npmjs/-/sprintf-js/1.0.3, BSD-3-Clause, approved, #949
+npm/npmjs/-/stable/0.1.8, MIT, approved, clearlydefined
+npm/npmjs/-/stack-utils/2.0.6, MIT, approved, clearlydefined
+npm/npmjs/-/stackframe/1.3.4, MIT, approved, clearlydefined
+npm/npmjs/-/statuses/2.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/stop-iteration-iterator/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/store2/2.14.2, GPL-3.0-only OR MIT, approved, #3240
+npm/npmjs/-/storybook/7.0.21, MIT, approved, #9064
+npm/npmjs/-/stream-shift/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/string-argv/0.3.2, MIT, approved, clearlydefined
+npm/npmjs/-/string-convert/0.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/string-hash/1.1.3, CC0-1.0, approved, clearlydefined
+npm/npmjs/-/string-length/4.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/string-width/4.2.3, MIT, approved, clearlydefined
+npm/npmjs/-/string-width/5.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/string.prototype.matchall/4.0.8, MIT, approved, #4571
+npm/npmjs/-/string.prototype.trim/1.2.7, MIT, approved, clearlydefined
+npm/npmjs/-/string.prototype.trimend/1.0.6, MIT, approved, #4564
+npm/npmjs/-/string.prototype.trimstart/1.0.6, MIT, approved, #4647
+npm/npmjs/-/string_decoder/1.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/string_decoder/1.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/strip-ansi/6.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/strip-ansi/7.1.0, MIT, approved, #8735
+npm/npmjs/-/strip-bom/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/strip-bom/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/strip-final-newline/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/strip-final-newline/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/strip-indent/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/strip-json-comments/3.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/style-inject/0.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/style-loader/3.3.3, MIT, approved, clearlydefined
+npm/npmjs/-/stylehacks/5.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/stylis/4.2.0, MIT, approved, #8409
+npm/npmjs/-/supports-color/5.5.0, MIT, approved, clearlydefined
+npm/npmjs/-/supports-color/7.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/supports-color/8.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/supports-hyperlinks/2.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/supports-preserve-symlinks-flag/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/svgo/2.8.0, MIT AND (0BSD AND BSD-2-Clause AND MIT) AND Apache-2.0, approved, #2989
+npm/npmjs/-/symbol-tree/3.2.4, MIT, approved, clearlydefined
+npm/npmjs/-/synchronous-promise/2.0.17, BSD-3-Clause, approved, clearlydefined
+npm/npmjs/-/tapable/2.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/tar-fs/2.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/tar-stream/2.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/tar/6.1.15, ISC, approved, #4566
+npm/npmjs/-/telejson/7.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/temp-dir/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/temp/0.8.4, MIT, approved, clearlydefined
+npm/npmjs/-/tempy/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/terminal-link/2.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/terser-webpack-plugin/5.3.9, MIT AND (Apache-2.0 AND MIT) AND Apache-2.0, approved, #7461
+npm/npmjs/-/terser/5.18.0, BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause, approved, #8970
+npm/npmjs/-/test-exclude/6.0.0, ISC, approved, clearlydefined
+npm/npmjs/-/text-table/0.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/through/2.3.8, Apache-2.0 AND MIT, approved, #1036
+npm/npmjs/-/through2/2.0.5, MIT, approved, clearlydefined
+npm/npmjs/-/tmpl/1.0.5, BSD-3-Clause, approved, clearlydefined
+npm/npmjs/-/to-fast-properties/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/to-regex-range/5.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/toidentifier/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/tough-cookie/4.1.3, BSD-3-Clause AND MIT, approved, #8743
+npm/npmjs/-/tr46/0.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/tr46/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/ts-dedent/2.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/tsconfig-paths/3.14.2, MIT, approved, clearlydefined
+npm/npmjs/-/tslib/1.14.1, 0BSD, approved, clearlydefined
+npm/npmjs/-/tslib/2.5.3, 0BSD, approved, #6747
+npm/npmjs/-/tsutils/3.21.0, MIT, approved, clearlydefined
+npm/npmjs/-/type-check/0.3.2, MIT, approved, clearlydefined
+npm/npmjs/-/type-check/0.4.0, MIT, approved, clearlydefined
+npm/npmjs/-/type-detect/4.0.8, MIT, approved, clearlydefined
+npm/npmjs/-/type-fest/0.16.0, MIT OR (CC0-1.0 AND MIT), approved, clearlydefined
+npm/npmjs/-/type-fest/0.20.2, MIT OR (CC0-1.0 AND MIT), approved, clearlydefined
+npm/npmjs/-/type-fest/0.21.3, MIT OR (CC0-1.0 AND MIT), approved, clearlydefined
+npm/npmjs/-/type-fest/0.6.0, MIT OR (CC0-1.0 AND MIT), approved, clearlydefined
+npm/npmjs/-/type-fest/0.8.1, MIT OR (CC0-1.0 AND MIT), approved, clearlydefined
+npm/npmjs/-/type-fest/2.19.0, CC0-1.0 OR MIT OR (CC0-1.0 AND MIT), approved, clearlydefined
+npm/npmjs/-/type-is/1.6.18, MIT, approved, clearlydefined
+npm/npmjs/-/typed-array-length/1.0.4, MIT, approved, #6246
+npm/npmjs/-/typedarray-to-buffer/3.1.5, MIT, approved, clearlydefined
+npm/npmjs/-/typedarray/0.0.6, MIT, approved, clearlydefined
+npm/npmjs/-/typescript/5.1.3, Apache-2.0 AND ODbL-1.0 AND MIT, approved, #8683
+npm/npmjs/-/uglify-js/3.17.4, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/unbox-primitive/1.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/unfetch/4.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/unicode-canonical-property-names-ecmascript/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/unicode-match-property-ecmascript/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/unicode-match-property-value-ecmascript/2.1.0, MIT, approved, #4991
+npm/npmjs/-/unicode-property-aliases-ecmascript/2.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/unique-string/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/unist-util-is/4.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/unist-util-visit-parents/3.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/unist-util-visit/2.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/universalify/0.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/universalify/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/unpipe/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/unplugin/0.10.2, MIT, approved, clearlydefined
+npm/npmjs/-/untildify/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/update-browserslist-db/1.0.11, MIT, approved, #8237
+npm/npmjs/-/uri-js/4.4.1, BSD-2-Clause, approved, #1086
+npm/npmjs/-/url-parse/1.5.10, MIT, approved, clearlydefined
+npm/npmjs/-/use-resize-observer/9.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/util-deprecate/1.0.2, MIT, approved, #5885
+npm/npmjs/-/util/0.12.5, MIT, approved, clearlydefined
+npm/npmjs/-/utila/0.4.0, MIT, approved, clearlydefined
+npm/npmjs/-/utils-merge/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/uuid/9.0.0, MIT AND (BSD-3-Clause AND MIT), approved, #6869
+npm/npmjs/-/v8-to-istanbul/9.1.0, ISC, approved, clearlydefined
+npm/npmjs/-/validate-npm-package-license/3.0.4, Apache-2.0 AND (Apache-2.0 AND BSD-2-Clause), approved, #2562
+npm/npmjs/-/vary/1.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/w3c-xmlserializer/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/walker/1.0.8, Apache-2.0, approved, clearlydefined
+npm/npmjs/-/watchpack/2.4.0, MIT, approved, clearlydefined
+npm/npmjs/-/wcwidth/1.0.1, MIT, approved, #944
+npm/npmjs/-/webidl-conversions/3.0.1, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/webidl-conversions/7.0.0, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/webpack-dev-middleware/5.3.3, MIT, approved, clearlydefined
+npm/npmjs/-/webpack-hot-middleware/2.25.3, MIT, approved, #3239
+npm/npmjs/-/webpack-sources/3.2.3, MIT, approved, clearlydefined
+npm/npmjs/-/webpack-virtual-modules/0.4.6, MIT, approved, clearlydefined
+npm/npmjs/-/webpack/5.87.0, MIT, approved, #9035
+npm/npmjs/-/whatwg-encoding/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/whatwg-mimetype/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/whatwg-url/11.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/whatwg-url/5.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/which-boxed-primitive/1.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/which-collection/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/which-typed-array/1.1.9, MIT, approved, #4864
+npm/npmjs/-/which/2.0.2, ISC, approved, clearlydefined
+npm/npmjs/-/wide-align/1.1.5, ISC, approved, clearlydefined
+npm/npmjs/-/widest-line/3.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/word-wrap/1.2.3, MIT, approved, clearlydefined
+npm/npmjs/-/wordwrap/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/wrap-ansi/6.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/wrap-ansi/7.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/wrappy/1.0.2, ISC, approved, clearlydefined
+npm/npmjs/-/write-file-atomic/2.4.3, ISC, approved, clearlydefined
+npm/npmjs/-/write-file-atomic/3.0.3, ISC, approved, clearlydefined
+npm/npmjs/-/write-file-atomic/4.0.2, ISC, approved, clearlydefined
+npm/npmjs/-/ws/6.2.2, MIT, approved, clearlydefined
+npm/npmjs/-/ws/8.13.0, MIT, approved, #7453
+npm/npmjs/-/xml-name-validator/4.0.0, Apache-2.0, approved, clearlydefined
+npm/npmjs/-/xmlchars/2.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/xtend/4.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/y18n/5.0.8, ISC, approved, clearlydefined
+npm/npmjs/-/yallist/3.1.1, ISC, approved, clearlydefined
+npm/npmjs/-/yallist/4.0.0, ISC, approved, clearlydefined
+npm/npmjs/-/yaml/1.10.2, ISC, approved, clearlydefined
+npm/npmjs/-/yaml/2.3.1, ISC AND 0BSD, approved, #9019
+npm/npmjs/-/yargs-parser/20.2.9, ISC, approved, clearlydefined
+npm/npmjs/-/yargs-parser/21.1.1, ISC, approved, clearlydefined
+npm/npmjs/-/yargs/16.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/yargs/17.7.2, MIT, approved, #8222
+npm/npmjs/-/yauzl/2.10.0, MIT, approved, clearlydefined
+npm/npmjs/-/yocto-queue/0.1.0, MIT, approved, clearlydefined
+npm/npmjs/@ampproject/remapping/2.2.1, Apache-2.0, approved, clearlydefined
+npm/npmjs/@aw-web-design/x-default-browser/1.4.88, MIT, approved, clearlydefined
+npm/npmjs/@babel/code-frame/7.22.5, MIT, approved, #8946
+npm/npmjs/@babel/compat-data/7.22.5, MIT, approved, #9062
+npm/npmjs/@babel/core/7.21.8, MIT AND (BSD-2-Clause AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #7466
+npm/npmjs/@babel/core/7.22.5, MIT, approved, #9057
+npm/npmjs/@babel/generator/7.21.9, MIT AND (BSD-2-Clause AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #7470
+npm/npmjs/@babel/generator/7.22.5, MIT, approved, #9002
+npm/npmjs/@babel/helper-annotate-as-pure/7.22.5, MIT, approved, #9009
+npm/npmjs/@babel/helper-builder-binary-assignment-operator-visitor/7.22.5, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #8765
+npm/npmjs/@babel/helper-compilation-targets/7.22.5, MIT, approved, #9037
+npm/npmjs/@babel/helper-create-class-features-plugin/7.22.5, MIT, approved, #8985
+npm/npmjs/@babel/helper-create-regexp-features-plugin/7.22.5, MIT, approved, #8950
+npm/npmjs/@babel/helper-define-polyfill-provider/0.3.3, MIT, approved, clearlydefined
+npm/npmjs/@babel/helper-define-polyfill-provider/0.4.0, MIT, approved, clearlydefined
+npm/npmjs/@babel/helper-environment-visitor/7.22.5, MIT, approved, #8934
+npm/npmjs/@babel/helper-function-name/7.22.5, MIT, approved, #9071
+npm/npmjs/@babel/helper-hoist-variables/7.22.5, MIT, approved, #8957
+npm/npmjs/@babel/helper-member-expression-to-functions/7.22.5, MIT, approved, #8966
+npm/npmjs/@babel/helper-module-imports/7.22.5, MIT, approved, #8944
+npm/npmjs/@babel/helper-module-transforms/7.22.5, MIT, approved, #9067
+npm/npmjs/@babel/helper-optimise-call-expression/7.22.5, MIT, approved, #9011
+npm/npmjs/@babel/helper-plugin-utils/7.22.5, MIT, approved, #9012
+npm/npmjs/@babel/helper-remap-async-to-generator/7.22.5, MIT, approved, #8981
+npm/npmjs/@babel/helper-replace-supers/7.22.5, MIT, approved, #9068
+npm/npmjs/@babel/helper-simple-access/7.22.5, MIT, approved, #9048
+npm/npmjs/@babel/helper-skip-transparent-expression-wrappers/7.22.5, MIT, approved, #8984
+npm/npmjs/@babel/helper-split-export-declaration/7.22.5, MIT, approved, #8938
+npm/npmjs/@babel/helper-string-parser/7.22.5, MIT, approved, #8962
+npm/npmjs/@babel/helper-validator-identifier/7.22.5, MIT, approved, #8955
+npm/npmjs/@babel/helper-validator-option/7.22.5, MIT, approved, #8961
+npm/npmjs/@babel/helper-wrap-function/7.22.5, MIT, approved, #8951
+npm/npmjs/@babel/helpers/7.22.5, MIT, approved, #9060
+npm/npmjs/@babel/highlight/7.22.5, MIT, approved, #9073
+npm/npmjs/@babel/parser/7.21.9, MIT AND (BSD-2-Clause AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #7455
+npm/npmjs/@babel/parser/7.22.5, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #8784
+npm/npmjs/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.22.5, MIT, approved, #9072
+npm/npmjs/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/7.22.5, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #8762
+npm/npmjs/@babel/plugin-proposal-async-generator-functions/7.20.7, MIT, approved, #4607
+npm/npmjs/@babel/plugin-proposal-class-properties/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-proposal-class-static-block/7.21.0, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-proposal-dynamic-import/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-proposal-export-namespace-from/7.18.9, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-proposal-json-strings/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-proposal-logical-assignment-operators/7.20.7, BSD-2-Clause AND MIT, approved, #5991
+npm/npmjs/@babel/plugin-proposal-nullish-coalescing-operator/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-proposal-numeric-separator/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-proposal-object-rest-spread/7.20.7, MIT, approved, #4581
+npm/npmjs/@babel/plugin-proposal-optional-catch-binding/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-proposal-optional-chaining/7.21.0, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-proposal-private-methods/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-proposal-private-property-in-object/7.21.0-placeholder-for-preset-env.2, MIT, approved, #8768
+npm/npmjs/@babel/plugin-proposal-private-property-in-object/7.21.11, MIT, approved, #8768
+npm/npmjs/@babel/plugin-proposal-unicode-property-regex/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-async-generators/7.8.4, MIT, approved, #1973
+npm/npmjs/@babel/plugin-syntax-bigint/7.8.3, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-class-properties/7.12.13, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-class-static-block/7.14.5, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-dynamic-import/7.8.3, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-export-namespace-from/7.8.3, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-flow/7.22.5, MIT, approved, #9076
+npm/npmjs/@babel/plugin-syntax-import-assertions/7.22.5, MIT, approved, #9042
+npm/npmjs/@babel/plugin-syntax-import-attributes/7.22.5, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #8739
+npm/npmjs/@babel/plugin-syntax-import-meta/7.10.4, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-json-strings/7.8.3, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-jsx/7.22.5, MIT, approved, #9014
+npm/npmjs/@babel/plugin-syntax-logical-assignment-operators/7.10.4, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-nullish-coalescing-operator/7.8.3, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-numeric-separator/7.10.4, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-object-rest-spread/7.8.3, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-optional-catch-binding/7.8.3, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-optional-chaining/7.8.3, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-private-property-in-object/7.14.5, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-top-level-await/7.14.5, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-typescript/7.22.5, MIT, approved, #8994
+npm/npmjs/@babel/plugin-syntax-unicode-sets-regex/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-transform-arrow-functions/7.22.5, MIT, approved, #9046
+npm/npmjs/@babel/plugin-transform-async-generator-functions/7.22.5, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #8756
+npm/npmjs/@babel/plugin-transform-async-to-generator/7.22.5, MIT, approved, #8963
+npm/npmjs/@babel/plugin-transform-block-scoped-functions/7.22.5, MIT, approved, #9008
+npm/npmjs/@babel/plugin-transform-block-scoping/7.22.5, MIT, approved, #8945
+npm/npmjs/@babel/plugin-transform-class-properties/7.22.5, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #8769
+npm/npmjs/@babel/plugin-transform-class-static-block/7.22.5, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #8753
+npm/npmjs/@babel/plugin-transform-classes/7.22.5, MIT, approved, #8975
+npm/npmjs/@babel/plugin-transform-computed-properties/7.22.5, MIT, approved, #9022
+npm/npmjs/@babel/plugin-transform-destructuring/7.22.5, MIT, approved, #8971
+npm/npmjs/@babel/plugin-transform-dotall-regex/7.22.5, MIT, approved, #9056
+npm/npmjs/@babel/plugin-transform-duplicate-keys/7.22.5, MIT, approved, #9039
+npm/npmjs/@babel/plugin-transform-dynamic-import/7.22.5, MIT, approved, #9016
+npm/npmjs/@babel/plugin-transform-exponentiation-operator/7.22.5, MIT, approved, #9001
+npm/npmjs/@babel/plugin-transform-export-namespace-from/7.22.5, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #8731
+npm/npmjs/@babel/plugin-transform-flow-strip-types/7.22.5, MIT, approved, #9023
+npm/npmjs/@babel/plugin-transform-for-of/7.22.5, MIT, approved, #8933
+npm/npmjs/@babel/plugin-transform-function-name/7.22.5, MIT, approved, #8936
+npm/npmjs/@babel/plugin-transform-json-strings/7.22.5, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #8747
+npm/npmjs/@babel/plugin-transform-literals/7.22.5, MIT, approved, #9044
+npm/npmjs/@babel/plugin-transform-logical-assignment-operators/7.22.5, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #8720
+npm/npmjs/@babel/plugin-transform-member-expression-literals/7.22.5, MIT, approved, #9065
+npm/npmjs/@babel/plugin-transform-modules-amd/7.22.5, MIT, approved, #8925
+npm/npmjs/@babel/plugin-transform-modules-commonjs/7.22.5, MIT, approved, #9021
+npm/npmjs/@babel/plugin-transform-modules-systemjs/7.22.5, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #8767
+npm/npmjs/@babel/plugin-transform-modules-umd/7.22.5, MIT, approved, #8997
+npm/npmjs/@babel/plugin-transform-named-capturing-groups-regex/7.22.5, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #8738
+npm/npmjs/@babel/plugin-transform-new-target/7.22.5, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #8737
+npm/npmjs/@babel/plugin-transform-nullish-coalescing-operator/7.22.5, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #8763
+npm/npmjs/@babel/plugin-transform-numeric-separator/7.22.5, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #8734
+npm/npmjs/@babel/plugin-transform-object-rest-spread/7.22.5, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #8726
+npm/npmjs/@babel/plugin-transform-object-super/7.22.5, MIT, approved, #9045
+npm/npmjs/@babel/plugin-transform-optional-catch-binding/7.22.5, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #8723
+npm/npmjs/@babel/plugin-transform-optional-chaining/7.22.5, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #8740
+npm/npmjs/@babel/plugin-transform-parameters/7.22.5, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #8741
+npm/npmjs/@babel/plugin-transform-private-methods/7.22.5, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #8757
+npm/npmjs/@babel/plugin-transform-private-property-in-object/7.22.5, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #8725
+npm/npmjs/@babel/plugin-transform-property-literals/7.22.5, MIT, approved, #8922
+npm/npmjs/@babel/plugin-transform-react-display-name/7.22.5, MIT, approved, #9028
+npm/npmjs/@babel/plugin-transform-react-jsx-development/7.22.5, MIT, approved, #9025
+npm/npmjs/@babel/plugin-transform-react-jsx/7.22.5, MIT, approved, #9007
+npm/npmjs/@babel/plugin-transform-react-pure-annotations/7.22.5, MIT, approved, #9066
+npm/npmjs/@babel/plugin-transform-regenerator/7.22.5, MIT, approved, #9063
+npm/npmjs/@babel/plugin-transform-reserved-words/7.22.5, MIT, approved, #9029
+npm/npmjs/@babel/plugin-transform-shorthand-properties/7.22.5, MIT, approved, #9013
+npm/npmjs/@babel/plugin-transform-spread/7.22.5, MIT, approved, #8996
+npm/npmjs/@babel/plugin-transform-sticky-regex/7.22.5, MIT, approved, #8988
+npm/npmjs/@babel/plugin-transform-template-literals/7.22.5, MIT, approved, #9080
+npm/npmjs/@babel/plugin-transform-typeof-symbol/7.22.5, MIT, approved, #9061
+npm/npmjs/@babel/plugin-transform-typescript/7.22.5, MIT, approved, #8948
+npm/npmjs/@babel/plugin-transform-unicode-escapes/7.22.5, MIT, approved, #8998
+npm/npmjs/@babel/plugin-transform-unicode-property-regex/7.22.5, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #8727
+npm/npmjs/@babel/plugin-transform-unicode-regex/7.22.5, MIT, approved, #8929
+npm/npmjs/@babel/plugin-transform-unicode-sets-regex/7.22.5, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #8755
+npm/npmjs/@babel/preset-env/7.21.5, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #8235
+npm/npmjs/@babel/preset-env/7.22.5, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #8748
+npm/npmjs/@babel/preset-flow/7.22.5, MIT, approved, #8974
+npm/npmjs/@babel/preset-modules/0.1.5, MIT, approved, clearlydefined
+npm/npmjs/@babel/preset-react/7.22.5, MIT, approved, #8987
+npm/npmjs/@babel/preset-typescript/7.22.5, MIT, approved, #9074
+npm/npmjs/@babel/register/7.22.5, MIT, approved, #8959
+npm/npmjs/@babel/regjsgen/0.8.0, MIT, approved, #7149
+npm/npmjs/@babel/runtime/7.22.5, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #8730
+npm/npmjs/@babel/template/7.22.5, MIT, approved, #9017
+npm/npmjs/@babel/traverse/7.21.5, MIT AND (BSD-2-Clause AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #7472
+npm/npmjs/@babel/traverse/7.22.5, MIT, approved, #8954
+npm/npmjs/@babel/types/7.21.5, MIT AND (BSD-2-Clause AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #7473
+npm/npmjs/@babel/types/7.22.5, MIT, approved, #8967
+npm/npmjs/@base2/pretty-print-object/1.0.1, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/@bcoe/v8-coverage/0.2.3, ISC AND MIT, approved, clearlydefined
+npm/npmjs/@colors/colors/1.5.0, MIT, approved, clearlydefined
+npm/npmjs/@date-io/core/2.16.0, MIT, approved, clearlydefined
+npm/npmjs/@date-io/date-fns/2.16.0, MIT, approved, clearlydefined
+npm/npmjs/@date-io/dayjs/2.16.0, MIT, approved, clearlydefined
+npm/npmjs/@date-io/luxon/2.16.1, MIT, approved, clearlydefined
+npm/npmjs/@date-io/moment/2.16.1, MIT, approved, clearlydefined
+npm/npmjs/@discoveryjs/json-ext/0.5.7, MIT, approved, clearlydefined
+npm/npmjs/@emotion/babel-plugin/11.11.0, MIT, approved, #8386
+npm/npmjs/@emotion/cache/11.11.0, MIT, approved, #8401
+npm/npmjs/@emotion/hash/0.9.1, MIT, approved, #8394
+npm/npmjs/@emotion/is-prop-valid/1.2.1, MIT, approved, #8392
+npm/npmjs/@emotion/memoize/0.8.1, MIT, approved, #8408
+npm/npmjs/@emotion/react/11.11.1, MIT AND (BSD-3-Clause AND MIT), approved, #8931
+npm/npmjs/@emotion/serialize/1.1.2, MIT, approved, #8417
+npm/npmjs/@emotion/sheet/1.2.2, MIT, approved, #8389
+npm/npmjs/@emotion/styled/11.11.0, MIT, approved, clearlydefined
+npm/npmjs/@emotion/unitless/0.8.1, MIT, approved, #8403
+npm/npmjs/@emotion/use-insertion-effect-with-fallbacks/1.0.1, MIT, approved, #8419
+npm/npmjs/@emotion/utils/1.2.1, MIT, approved, #8415
+npm/npmjs/@emotion/weak-memoize/0.3.1, MIT, approved, #8402
+npm/npmjs/@esbuild/android-arm/0.17.19, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #7422
+npm/npmjs/@esbuild/android-arm64/0.17.19, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #7550
+npm/npmjs/@esbuild/android-x64/0.17.19, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #7428
+npm/npmjs/@esbuild/darwin-arm64/0.17.19, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #7542
+npm/npmjs/@esbuild/darwin-x64/0.17.19, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #7549
+npm/npmjs/@esbuild/freebsd-arm64/0.17.19, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #7533
+npm/npmjs/@esbuild/freebsd-x64/0.17.19, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #7532
+npm/npmjs/@esbuild/linux-arm/0.17.19, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #7534
+npm/npmjs/@esbuild/linux-arm64/0.17.19, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #7525
+npm/npmjs/@esbuild/linux-ia32/0.17.19, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #7551
+npm/npmjs/@esbuild/linux-loong64/0.17.19, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #7530
+npm/npmjs/@esbuild/linux-mips64el/0.17.19, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #7526
+npm/npmjs/@esbuild/linux-ppc64/0.17.19, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #7552
+npm/npmjs/@esbuild/linux-riscv64/0.17.19, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #7545
+npm/npmjs/@esbuild/linux-s390x/0.17.19, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #7544
+npm/npmjs/@esbuild/linux-x64/0.17.19, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #7539
+npm/npmjs/@esbuild/netbsd-x64/0.17.19, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #7535
+npm/npmjs/@esbuild/openbsd-x64/0.17.19, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #7529
+npm/npmjs/@esbuild/sunos-x64/0.17.19, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #7528
+npm/npmjs/@esbuild/win32-arm64/0.17.19, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #7538
+npm/npmjs/@esbuild/win32-ia32/0.17.19, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #7536
+npm/npmjs/@esbuild/win32-x64/0.17.19, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #7547
+npm/npmjs/@eslint-community/eslint-utils/4.4.0, MIT, approved, #8032
+npm/npmjs/@eslint-community/regexpp/4.5.1, MIT, approved, clearlydefined
+npm/npmjs/@eslint/eslintrc/2.0.3, MIT, approved, #7481
+npm/npmjs/@eslint/js/8.37.0, MIT, approved, clearlydefined
+npm/npmjs/@fal-works/esbuild-plugin-global-externals/2.1.2, MIT, approved, clearlydefined
+npm/npmjs/@humanwhocodes/config-array/0.11.10, Apache-2.0, approved, #5876
+npm/npmjs/@humanwhocodes/module-importer/1.0.1, Apache-2.0, approved, clearlydefined
+npm/npmjs/@humanwhocodes/object-schema/1.2.1, BSD-3-Clause, approved, clearlydefined
+npm/npmjs/@istanbuljs/load-nyc-config/1.1.0, ISC, approved, clearlydefined
+npm/npmjs/@istanbuljs/schema/0.1.3, MIT, approved, clearlydefined
+npm/npmjs/@jest/console/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/@jest/core/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/@jest/environment/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/@jest/environment/29.5.0, MIT, approved, clearlydefined
+npm/npmjs/@jest/expect-utils/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/@jest/expect/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/@jest/fake-timers/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/@jest/fake-timers/29.5.0, MIT, approved, clearlydefined
+npm/npmjs/@jest/globals/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/@jest/reporters/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/@jest/schemas/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/@jest/schemas/29.4.3, MIT, approved, clearlydefined
+npm/npmjs/@jest/source-map/28.1.2, MIT, approved, clearlydefined
+npm/npmjs/@jest/test-result/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/@jest/test-sequencer/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/@jest/transform/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/@jest/transform/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/@jest/transform/29.5.0, MIT, approved, clearlydefined
+npm/npmjs/@jest/types/27.5.1, 0BSD AND Apache-2.0 AND BSD-2-Clause AND MIT, approved, #1960
+npm/npmjs/@jest/types/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/@jest/types/29.5.0, MIT, approved, clearlydefined
+npm/npmjs/@jridgewell/gen-mapping/0.3.3, MIT, approved, clearlydefined
+npm/npmjs/@jridgewell/resolve-uri/3.1.0, MIT, approved, clearlydefined
+npm/npmjs/@jridgewell/set-array/1.1.2, MIT, approved, clearlydefined
+npm/npmjs/@jridgewell/source-map/0.3.3, MIT, approved, clearlydefined
+npm/npmjs/@jridgewell/sourcemap-codec/1.4.14, MIT, approved, clearlydefined
+npm/npmjs/@jridgewell/sourcemap-codec/1.4.15, MIT, approved, clearlydefined
+npm/npmjs/@jridgewell/trace-mapping/0.3.18, MIT, approved, clearlydefined
+npm/npmjs/@juggle/resize-observer/3.4.0, Apache-2.0, approved, clearlydefined
+npm/npmjs/@mdx-js/react/2.3.0, MIT, approved, clearlydefined
+npm/npmjs/@mui/base/5.0.0-beta.4, MIT, approved, #2992
+npm/npmjs/@mui/core-downloads-tracker/5.13.4, MIT, approved, #8983
+npm/npmjs/@mui/icons-material/5.11.16, MIT AND OFL-1.1 AND CC-BY-3.0, approved, #6621
+npm/npmjs/@mui/material/5.13.5, MIT, approved, #8930
+npm/npmjs/@mui/private-theming/5.13.1, MIT, approved, #9047
+npm/npmjs/@mui/styled-engine/5.13.2, MIT, approved, #8968
+npm/npmjs/@mui/system/5.13.5, MIT, approved, #9075
+npm/npmjs/@mui/types/7.2.4, MIT, approved, clearlydefined
+npm/npmjs/@mui/utils/5.13.1, MIT, approved, #8982
+npm/npmjs/@mui/x-data-grid/5.17.26, MIT, approved, #3248
+npm/npmjs/@mui/x-date-pickers/5.0.20, MIT, approved, #3247
+npm/npmjs/@ndelangen/get-tarball/3.0.9, MIT, approved, #8958
+npm/npmjs/@nodelib/fs.scandir/2.1.5, MIT, approved, clearlydefined
+npm/npmjs/@nodelib/fs.stat/2.0.5, MIT, approved, clearlydefined
+npm/npmjs/@nodelib/fs.walk/1.2.8, MIT, approved, clearlydefined
+npm/npmjs/@pmmmwh/react-refresh-webpack-plugin/0.5.10, MIT, approved, clearlydefined
+npm/npmjs/@popperjs/core/2.11.8, MIT, approved, clearlydefined
+npm/npmjs/@rollup/plugin-commonjs/25.0.1, MIT, approved, #9003
+npm/npmjs/@rollup/plugin-image/3.0.2, MIT, approved, clearlydefined
+npm/npmjs/@rollup/plugin-node-resolve/15.1.0, MIT, approved, #8924
+npm/npmjs/@rollup/plugin-typescript/11.1.1, MIT, approved, clearlydefined
+npm/npmjs/@rollup/pluginutils/5.0.2, MIT, approved, clearlydefined
+npm/npmjs/@sinclair/typebox/0.24.51, MIT, approved, #3330
+npm/npmjs/@sinclair/typebox/0.25.24, MIT, approved, clearlydefined
+npm/npmjs/@sinonjs/commons/1.8.6, BSD-3-Clause, approved, #4340
+npm/npmjs/@sinonjs/commons/3.0.0, BSD-3-Clause, approved, clearlydefined
+npm/npmjs/@sinonjs/fake-timers/10.2.0, BSD-3-Clause, approved, #8744
+npm/npmjs/@sinonjs/fake-timers/9.1.2, BSD-3-Clause, approved, #1957
+npm/npmjs/@storybook/addon-actions/7.0.21, MIT, approved, #8972
+npm/npmjs/@storybook/addon-backgrounds/7.0.21, MIT, approved, #8923
+npm/npmjs/@storybook/addon-controls/7.0.21, MIT, approved, #9006
+npm/npmjs/@storybook/addon-docs/7.0.21, MIT, approved, #8928
+npm/npmjs/@storybook/addon-essentials/7.0.21, MIT, approved, #9077
+npm/npmjs/@storybook/addon-highlight/7.0.21, MIT, approved, #9033
+npm/npmjs/@storybook/addon-links/7.0.21, MIT, approved, #8979
+npm/npmjs/@storybook/addon-measure/7.0.21, MIT, approved, #9050
+npm/npmjs/@storybook/addon-outline/7.0.21, MIT, approved, #8953
+npm/npmjs/@storybook/addon-toolbars/7.0.21, MIT, approved, #8990
+npm/npmjs/@storybook/addon-viewport/7.0.21, MIT, approved, #9036
+npm/npmjs/@storybook/addons/7.0.21, MIT, approved, #9005
+npm/npmjs/@storybook/api/7.0.21, MIT, approved, #8965
+npm/npmjs/@storybook/blocks/7.0.21, MIT, approved, #8993
+npm/npmjs/@storybook/builder-manager/7.0.21, MIT, approved, #9000
+npm/npmjs/@storybook/builder-webpack5/7.0.21, MIT, approved, #8992
+npm/npmjs/@storybook/channel-postmessage/7.0.21, MIT, approved, #8949
+npm/npmjs/@storybook/channel-websocket/7.0.21, MIT, approved, #8940
+npm/npmjs/@storybook/channels/7.0.21, MIT, approved, #9027
+npm/npmjs/@storybook/cli/7.0.21, MIT, approved, #9015
+npm/npmjs/@storybook/client-api/7.0.21, MIT, approved, #9059
+npm/npmjs/@storybook/client-logger/7.0.21, MIT, approved, #8977
+npm/npmjs/@storybook/codemod/7.0.21, MIT, approved, #9054
+npm/npmjs/@storybook/components/7.0.21, MIT, approved, #8942
+npm/npmjs/@storybook/core-client/7.0.21, MIT, approved, #8926
+npm/npmjs/@storybook/core-common/7.0.21, MIT, approved, #8960
+npm/npmjs/@storybook/core-events/7.0.21, MIT, approved, #9058
+npm/npmjs/@storybook/core-server/7.0.21, MIT, approved, #9018
+npm/npmjs/@storybook/core-webpack/7.0.21, MIT, approved, #9031
+npm/npmjs/@storybook/csf-plugin/7.0.21, MIT, approved, #9053
+npm/npmjs/@storybook/csf-tools/7.0.21, MIT, approved, #8995
+npm/npmjs/@storybook/csf/0.1.1, MIT, approved, #8941
+npm/npmjs/@storybook/docs-mdx/0.1.0, MIT, approved, clearlydefined
+npm/npmjs/@storybook/docs-tools/7.0.21, MIT, approved, #9070
+npm/npmjs/@storybook/global/5.0.0, MIT, approved, clearlydefined
+npm/npmjs/@storybook/manager-api/7.0.21, MIT, approved, #9041
+npm/npmjs/@storybook/manager/7.0.21, MIT, approved, #9055
+npm/npmjs/@storybook/mdx2-csf/1.1.0, MIT, approved, clearlydefined
+npm/npmjs/@storybook/node-logger/7.0.21, MIT, approved, #8956
+npm/npmjs/@storybook/postinstall/7.0.21, MIT, approved, #8943
+npm/npmjs/@storybook/preset-react-webpack/7.0.21, MIT, approved, #9024
+npm/npmjs/@storybook/preset-scss/1.0.3, MIT, approved, clearlydefined
+npm/npmjs/@storybook/preview-api/7.0.21, MIT, approved, #8989
+npm/npmjs/@storybook/preview/7.0.21, MIT, approved, #9026
+npm/npmjs/@storybook/react-docgen-typescript-plugin/1.0.6--canary.9.0c3f3b7.0, MIT, approved, clearlydefined
+npm/npmjs/@storybook/react-dom-shim/7.0.21, MIT, approved, #8978
+npm/npmjs/@storybook/react-webpack5/7.0.21, MIT, approved, #8937
+npm/npmjs/@storybook/react/7.0.21, MIT, approved, #8927
+npm/npmjs/@storybook/router/7.0.21, MIT, approved, #8980
+npm/npmjs/@storybook/store/7.0.21, MIT, approved, #9049
+npm/npmjs/@storybook/telemetry/7.0.21, MIT, approved, #8999
+npm/npmjs/@storybook/theming/7.0.21, MIT, approved, #9004
+npm/npmjs/@storybook/types/7.0.21, MIT, approved, #9020
+npm/npmjs/@testing-library/dom/9.3.1, MIT AND (MIT AND WTFPL), approved, #9038
+npm/npmjs/@testing-library/react/14.0.0, MIT AND (MIT AND WTFPL), approved, #9079
+npm/npmjs/@tootallnate/once/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/@trysound/sax/0.2.0, ISC, approved, clearlydefined
+npm/npmjs/@types/aria-query/5.0.1, MIT, approved, clearlydefined
+npm/npmjs/@types/autosuggest-highlight/3.2.0, MIT, approved, clearlydefined
+npm/npmjs/@types/babel__core/7.20.1, MIT, approved, clearlydefined
+npm/npmjs/@types/babel__generator/7.6.4, MIT, approved, clearlydefined
+npm/npmjs/@types/babel__template/7.4.1, MIT, approved, clearlydefined
+npm/npmjs/@types/babel__traverse/7.20.1, MIT, approved, #8935
+npm/npmjs/@types/body-parser/1.19.2, MIT, approved, clearlydefined
+npm/npmjs/@types/connect/3.4.35, MIT, approved, clearlydefined
+npm/npmjs/@types/detect-port/1.3.3, MIT, approved, #9034
+npm/npmjs/@types/doctrine/0.0.3, MIT, approved, clearlydefined
+npm/npmjs/@types/ejs/3.1.2, MIT, approved, clearlydefined
+npm/npmjs/@types/escodegen/0.0.6, MIT, approved, clearlydefined
+npm/npmjs/@types/eslint-scope/3.7.4, MIT, approved, clearlydefined
+npm/npmjs/@types/eslint/8.40.2, MIT, approved, #8764
+npm/npmjs/@types/estree/0.0.51, MIT, approved, clearlydefined
+npm/npmjs/@types/estree/1.0.1, MIT, approved, #8266
+npm/npmjs/@types/express-serve-static-core/4.17.35, MIT, approved, #6020
+npm/npmjs/@types/express/4.17.17, MIT, approved, #5760
+npm/npmjs/@types/find-cache-dir/3.2.1, MIT, approved, clearlydefined
+npm/npmjs/@types/glob/8.1.0, MIT, approved, clearlydefined
+npm/npmjs/@types/graceful-fs/4.1.6, MIT, approved, clearlydefined
+npm/npmjs/@types/html-minifier-terser/6.1.0, MIT, approved, clearlydefined
+npm/npmjs/@types/istanbul-lib-coverage/2.0.4, MIT, approved, clearlydefined
+npm/npmjs/@types/istanbul-lib-report/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/@types/istanbul-reports/3.0.1, MIT, approved, clearlydefined
+npm/npmjs/@types/jest/28.1.8, MIT, approved, clearlydefined
+npm/npmjs/@types/jsdom/20.0.1, MIT, approved, clearlydefined
+npm/npmjs/@types/json-schema/7.0.12, MIT, approved, clearlydefined
+npm/npmjs/@types/json5/0.0.29, MIT, approved, clearlydefined
+npm/npmjs/@types/lodash/4.14.195, MIT, approved, #4131
+npm/npmjs/@types/mdx/2.0.5, MIT, approved, clearlydefined
+npm/npmjs/@types/mime-types/2.1.1, MIT, approved, clearlydefined
+npm/npmjs/@types/mime/1.3.2, MIT, approved, clearlydefined
+npm/npmjs/@types/mime/3.0.1, MIT, approved, clearlydefined
+npm/npmjs/@types/minimatch/5.1.2, MIT, approved, clearlydefined
+npm/npmjs/@types/node-fetch/2.6.4, MIT, approved, clearlydefined
+npm/npmjs/@types/node/16.18.36, MIT, approved, #7082
+npm/npmjs/@types/node/20.3.1, MIT, approved, clearlydefined
+npm/npmjs/@types/normalize-package-data/2.4.1, MIT, approved, clearlydefined
+npm/npmjs/@types/npmlog/4.1.4, MIT, approved, clearlydefined
+npm/npmjs/@types/parse-json/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/@types/prettier/2.7.3, MIT, approved, #9030
+npm/npmjs/@types/pretty-hrtime/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/@types/prop-types/15.7.5, MIT, approved, clearlydefined
+npm/npmjs/@types/qs/6.9.7, MIT, approved, clearlydefined
+npm/npmjs/@types/range-parser/1.2.4, MIT, approved, clearlydefined
+npm/npmjs/@types/react-dom/18.2.5, MIT, approved, #8256
+npm/npmjs/@types/react-is/18.2.0, MIT, approved, #9131
+npm/npmjs/@types/react-slick/0.23.10, MIT, approved, clearlydefined
+npm/npmjs/@types/react-transition-group/4.4.6, MIT, approved, #8416
+npm/npmjs/@types/react/18.2.12, MIT, approved, #8234
+npm/npmjs/@types/resolve/1.20.2, MIT, approved, clearlydefined
+npm/npmjs/@types/scheduler/0.16.3, MIT, approved, #7582
+npm/npmjs/@types/semver/7.5.0, MIT, approved, clearlydefined
+npm/npmjs/@types/send/0.17.1, MIT, approved, clearlydefined
+npm/npmjs/@types/serve-static/1.15.1, MIT, approved, clearlydefined
+npm/npmjs/@types/stack-utils/2.0.1, MIT, approved, clearlydefined
+npm/npmjs/@types/tough-cookie/4.0.2, MIT, approved, clearlydefined
+npm/npmjs/@types/unist/2.0.6, MIT, approved, clearlydefined
+npm/npmjs/@types/yargs-parser/21.0.0, MIT, approved, clearlydefined
+npm/npmjs/@types/yargs/16.0.5, MIT, approved, clearlydefined
+npm/npmjs/@types/yargs/17.0.24, MIT, approved, #7054
+npm/npmjs/@typescript-eslint/eslint-plugin/5.59.11, BSD-2-Clause AND MIT, approved, #8045
+npm/npmjs/@typescript-eslint/parser/5.59.11, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/@typescript-eslint/scope-manager/5.59.11, MIT, approved, clearlydefined
+npm/npmjs/@typescript-eslint/type-utils/5.59.11, MIT, approved, clearlydefined
+npm/npmjs/@typescript-eslint/types/5.59.11, MIT, approved, clearlydefined
+npm/npmjs/@typescript-eslint/typescript-estree/5.59.11, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/@typescript-eslint/utils/5.59.11, MIT, approved, clearlydefined
+npm/npmjs/@typescript-eslint/visitor-keys/5.59.11, MIT, approved, clearlydefined
+npm/npmjs/@webassemblyjs/ast/1.11.6, MIT, approved, #7953
+npm/npmjs/@webassemblyjs/floating-point-hex-parser/1.11.6, MIT, approved, #7959
+npm/npmjs/@webassemblyjs/helper-api-error/1.11.6, MIT, approved, #7969
+npm/npmjs/@webassemblyjs/helper-buffer/1.11.6, MIT, approved, #7955
+npm/npmjs/@webassemblyjs/helper-numbers/1.11.6, MIT, approved, #7954
+npm/npmjs/@webassemblyjs/helper-wasm-bytecode/1.11.6, MIT, approved, #7962
+npm/npmjs/@webassemblyjs/helper-wasm-section/1.11.6, MIT, approved, #7960
+npm/npmjs/@webassemblyjs/ieee754/1.11.6, MIT, approved, #7961
+npm/npmjs/@webassemblyjs/leb128/1.11.6, Apache-2.0, approved, #7958
+npm/npmjs/@webassemblyjs/utf8/1.11.6, MIT, approved, #7966
+npm/npmjs/@webassemblyjs/wasm-edit/1.11.6, Apache-2.0 AND ISC AND MIT, approved, #2186
+npm/npmjs/@webassemblyjs/wasm-gen/1.11.6, MIT, approved, #7964
+npm/npmjs/@webassemblyjs/wasm-opt/1.11.6, MIT, approved, #7967
+npm/npmjs/@webassemblyjs/wasm-parser/1.11.6, MIT, approved, #7965
+npm/npmjs/@webassemblyjs/wast-printer/1.11.6, MIT, approved, #7957
+npm/npmjs/@xtuc/ieee754/1.2.0, BSD-3-Clause, approved, #123
+npm/npmjs/@xtuc/long/4.2.2, Apache-2.0, approved, clearlydefined
+npm/npmjs/@yarnpkg/esbuild-plugin-pnp/3.0.0-rc.15, BSD-2-Clause, approved, clearlydefined

--- a/scripts/check-dependencies.md
+++ b/scripts/check-dependencies.md
@@ -6,4 +6,4 @@ This workflow uses the executable jar in the download directory.
 
 In order to update the executable jar run the following command from the root directory:
 
-    curl -L --output ./scripts/download/org.eclipse.dash.licenses-0.0.1-SNAPSHOT.jar 'https://repo.eclipse.org/service/local/artifact/maven/redirect?r=dash-licenses&g=org.eclipse.dash&a=org.eclipse.dash.licenses&v=0.0.1-SNAPSHOT'
+    curl -L --output ./scripts/download/org.eclipse.dash.licenses-1.0.3-SNAPSHOT.jar 'https://repo.eclipse.org/service/local/artifact/maven/redirect?r=dash-licenses&g=org.eclipse.dash&a=org.eclipse.dash.licenses&v=1.0.3-SNAPSHOT'

--- a/scripts/check-dependencies.md
+++ b/scripts/check-dependencies.md
@@ -1,0 +1,9 @@
+# Check dependencies
+
+Dependencies are checked by the [Eclipse Dash License Tool](https://github.com/eclipse/dash-licenses) with a GitHub workflow (dependencies.yaml).
+
+This workflow uses the executable jar in the download directory.
+
+In order to update the executable jar run the following command from the root directory:
+
+    curl -L --output ./scripts/download/org.eclipse.dash.licenses-0.0.1-SNAPSHOT.jar 'https://repo.eclipse.org/service/local/artifact/maven/redirect?r=dash-licenses&g=org.eclipse.dash&a=org.eclipse.dash.licenses&v=0.0.1-SNAPSHOT'


### PR DESCRIPTION
## Description

- add workflow to check 3rd party dependencies with the [Eclipse Dash License Tool](https://github.com/eclipse/dash-licenses)
run with  dependencies file not changed: https://github.com/eclipse-tractusx/portal-backend/actions/runs/5375054212/jobs/9751059140
example run with dependencies file changed (repurposed unit testing und formatting workflow for testing): https://github.com/eclipse-tractusx/portal-backend/actions/runs/5374531262/jobs/9749999098
- change dependencies file to '-summary' format from Dash Tool

**Due to the new format in the dependencies file: once this PR is merged into dev, all open feature branches should be rebased to dev, as the dependencies check will fail otherwise.**

## Why

Dependencies check should be automated.

## Issue

n/a

## Checklist

Please delete options that are not relevant.

- [x] I have performed a self-review of my own changes
- [x] I have successfully tested my changes locally
