### PR TITLE
chore: change dash tool version

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Generate Dependencies file
-        run: java -jar ./scripts/download/org.eclipse.dash.licenses-1.0.3-SNAPSHOT.jar yarn.lock -project automotive.tractusx -summary DEPENDENCIES
+        run: java -jar ./scripts/download/org.eclipse.dash.licenses-1.0.2.jar yarn.lock -project automotive.tractusx -summary DEPENDENCIES
 
       - name: Check if dependencies were changed
         id: dependencies-changed

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1366,7 +1366,7 @@ npm/npmjs/@types/resolve/1.20.2, MIT, approved, clearlydefined
 npm/npmjs/@types/scheduler/0.16.3, MIT, approved, #7582
 npm/npmjs/@types/semver/7.5.0, MIT, approved, clearlydefined
 npm/npmjs/@types/send/0.17.1, MIT, approved, clearlydefined
-npm/npmjs/@types/serve-static/1.15.1, MIT, approved, clearlydefined
+npm/npmjs/@types/serve-static/1.15.1, MIT, approved, #9188
 npm/npmjs/@types/stack-utils/2.0.1, MIT, approved, clearlydefined
 npm/npmjs/@types/tough-cookie/4.0.2, MIT, approved, clearlydefined
 npm/npmjs/@types/unist/2.0.6, MIT, approved, clearlydefined

--- a/scripts/check-dependencies.md
+++ b/scripts/check-dependencies.md
@@ -6,4 +6,4 @@ This workflow uses the executable jar in the download directory.
 
 In order to update the executable jar run the following command from the root directory:
 
-    curl -L --output ./scripts/download/org.eclipse.dash.licenses-1.0.3-SNAPSHOT.jar 'https://repo.eclipse.org/service/local/artifact/maven/redirect?r=dash-licenses&g=org.eclipse.dash&a=org.eclipse.dash.licenses&v=1.0.3-SNAPSHOT'
+    curl -L --output ./scripts/download/org.eclipse.dash.licenses-1.0.2.jar 'https://repo.eclipse.org/service/local/artifact/maven/redirect?r=dash-licenses&g=org.eclipse.dash&a=org.eclipse.dash.licenses&v=1.0.2'


### PR DESCRIPTION
## Description

change dash tool version

## Why

1.0.3-SNAPSHOT did fail in portal-frontend, due to that change to a more stable version

## Issue

n/a

## Checklist

- [x] I have performed a self-review of my own changes
