### PR TITLE
chore(storybook): add storybook build and publish to workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,11 +26,22 @@ on:
     branches: 
       - main
 
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
       - name: Checkout repository
@@ -62,6 +73,21 @@ jobs:
 
       - name: Build Library
         run: yarn build
+
+      - name: Build Storybook
+        run: yarn build:storybook
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: 'storybook'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2
 
       - name: Publish Shared Components to npm
         run: npm publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,21 @@
 # Changelog
 
-## Unreleased
+## 2.0.5
+
+- Storybook
+  - Enable storybook build and publish in workflow
+
+## 2.0.4
+
+- Card
+  - Added condition for card(sub-menu) to fix coloring issue
+
+## 2.0.3
 
 - StaticTable
   - Add edit and input field functionality to Vertical Table
-- Card
-  - Added condition for card(sub-menu) to fix coloring issue
+
+## 2.0.1
 
 Extracted shared components from existing monorepo (links below).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catena-x/portal-shared-components",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Catena-X Portal Shared Components",
   "author": "Catena-X Contributors",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Description

Add storybook build and publish to workflow.

## Why

Storybook should be published on every release

## Issue

Jira: CPLP-2913

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
