### PR TITLE
feat(storybook): enable storybook publish in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,9 +39,9 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-latest
 
-#    environment:
-#      name: github-pages
-#      url: ${{ steps.deployment.outputs.page_url }}
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
       - name: Checkout repository
@@ -74,24 +74,20 @@ jobs:
       - name: Build Library
         run: yarn build
 
-#      Deactivated until GitHub Pages are ready
-#
-#      - name: Build Storybook
-#        run: yarn build:storybook
-#
-#      - name: Setup Pages
-#        uses: actions/configure-pages@v3
-#        with:
-#          enablement: true
-#
-#      - name: Upload artifact
-#        uses: actions/upload-pages-artifact@v1
-#        with:
-#          path: 'storybook'
-#
-#      - name: Deploy to GitHub Pages
-#        id: deployment
-#        uses: actions/deploy-pages@v2
+      - name: Build Storybook
+        run: yarn build:storybook
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: 'storybook'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2
 
       - name: Publish Shared Components to npm
         run: npm publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.0.7
+
+- Storybook
+  - Re-enable storybook build after GitHub pages are active
+
 ## 2.0.6
 
 - Dependencies

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Catena-X Portal Shared UI Components
 
 Contains the Shared UI Components that are used to build the [Portal Frontend](https://github.com/eclipse-tractusx/portal-frontend).
+Detailed documentation: https://eclipse-tractusx.github.io/portal-shared-components/
 
 ## User documentation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catena-x/portal-shared-components",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Catena-X Portal Shared Components",
   "author": "Catena-X Contributors",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Description

Enable storybook build and publish

## Why

This step was prepared and is now activated after GitHub pages have been enabled.

## Issue

ref. Jira CPLP-2913

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally