### PR TITLE
chore(build): enable workflow dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,9 @@ on:
       - main
     paths:
       - src/**
+      - package.json
       - yarn.lock
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Description

Enable manual workflow dispatch and trigger on package.json

## Why

Sometimes a manual trigger is needed and we don't need dummy commits. Also a package.json update should trigger the release because it may have an impact on the built artifacts.

## Issue

n/a

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
