### PR TITLE
feat(cards): enable custom image element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.28
+
+- Enable JSX elements on cards
+
 ## 2.0.27
 
 - Dialog styles fix

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catena-x/portal-shared-components",
-  "version": "2.0.27",
+  "version": "2.0.28",
   "description": "Catena-X Portal Shared Components",
   "author": "Catena-X Contributors",
   "license": "Apache-2.0",

--- a/src/components/basic/ErrorBar/ErrorBar.scss
+++ b/src/components/basic/ErrorBar/ErrorBar.scss
@@ -18,32 +18,32 @@
  ********************************************************************************/
 
 .errorBar {
-    width: 100%;
-    border: 1px solid #D91E18;
+  width: 100%;
+  border: 1px solid #d91e18;
+  display: flex;
+  align-items: center;
+  padding: 0px 50px;
+  height: 72px;
+  border-radius: 8px;
+  justify-content: space-between;
+
+  .iconWithText {
     display: flex;
     align-items: center;
-    padding: 0px 50px;
-    height: 72px;
-    border-radius: 8px;
-    justify-content: space-between;
 
-    .iconWithText {
-        display: flex;
-        align-items: center;
-
-        p {
-            font-size: 14px;
-        }
+    p {
+      font-size: 14px;
     }
+  }
 
-    .errorIcon {
-        color: #D91E18;
-        margin-right: 10px;
-    }
+  .errorIcon {
+    color: #d91e18;
+    margin-right: 10px;
+  }
 
-    .triggerButton {
-        text-transform: none;
-        height: 44px;
-        font-size: 14px;
-    }
+  .triggerButton {
+    text-transform: none;
+    height: 44px;
+    font-size: 14px;
+  }
 }

--- a/src/components/basic/ErrorBar/ErrorBar.stories.tsx
+++ b/src/components/basic/ErrorBar/ErrorBar.stories.tsx
@@ -36,5 +36,5 @@ ErrorBar.args = {
   errorText: 'Something went wrong. Try again',
   handleButton: () => {},
   showButton: true,
-  buttonText: 'Try Again'
+  buttonText: 'Try Again',
 }

--- a/src/components/basic/ErrorBar/ErrorBar.tsx
+++ b/src/components/basic/ErrorBar/ErrorBar.tsx
@@ -28,26 +28,30 @@ export const ErrorBar = ({
   errorText = '',
   handleButton,
   showButton,
-  buttonText
+  buttonText,
 }: {
   errorText?: string
   handleButton?: () => void
   showButton?: boolean
   buttonText?: string
 }) => {
-
   return (
     <Box className="errorBar">
       <Box className="iconWithText">
-        <ReportProblemIcon className='errorIcon' />
+        <ReportProblemIcon className="errorIcon" />
         <Typography variant="body2" color="#D91E18">
           {errorText}
         </Typography>
       </Box>
       {showButton && (
         <Box>
-          <Button endIcon={<ArrowForwardIcon />} variant='contained' color='primary'
-          onClick={handleButton} className='triggerButton'>
+          <Button
+            endIcon={<ArrowForwardIcon />}
+            variant="contained"
+            color="primary"
+            onClick={handleButton}
+            className="triggerButton"
+          >
             {buttonText}
           </Button>
         </Box>

--- a/src/components/basic/StaticTable/StaticTable.stories.tsx
+++ b/src/components/basic/StaticTable/StaticTable.stories.tsx
@@ -46,7 +46,8 @@ Table.args = {
       [
         {
           icon: true,
-          inputValue: 'Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries',
+          inputValue:
+            'Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries',
         },
         {
           icon: true,

--- a/src/components/basic/StaticTable/VerticalTable.tsx
+++ b/src/components/basic/StaticTable/VerticalTable.tsx
@@ -137,8 +137,8 @@ export const VerticalTable = ({
                 >
                   <div style={{ display: 'flex', alignItems: 'center' }}>
                     {inputField &&
-                      inputField.row === r &&
-                      inputField.column === c ? (
+                    inputField.row === r &&
+                    inputField.column === c ? (
                       renderInputField(r, c)
                     ) : (
                       <Link
@@ -161,44 +161,40 @@ export const VerticalTable = ({
                         </Typography>
                       </Link>
                     )}
-                    {data?.edit?.[r]?.[c].icon && !inputField && (
-                      c === 0 ?
-                        (
-                            <Tooltips
-                              color="dark"
-                              tooltipPlacement="bottom-start"
-                              tooltipText={data?.edit?.[r][c].inputValue ?? ''}
-                            >
-                              <HelpOutlineIcon
-                                sx={{
-                                  fontSize: '18px',
-                                  color: '#888888',
-                                  cursor: 'pointer',
-                                  '&:hover': {
-                                    color: '#0088CC',
-                                  },
-                                }}
-                              />
-                            </Tooltips>
-
-                        )
-                        : (
-                          <span style={{ marginLeft: 'auto' }}>
-                            <EditIcon
-                              onClick={(e) => handleEditFn(e, r, c)}
-                              sx={{
-                                fontSize: '18px',
-                                color: '#888888',
-                                cursor: 'pointer',
-                                '&:hover': {
-                                  color: '#0088CC',
-                                },
-                              }}
-                            />
-                          </span>
-                        )
-
-                    )}
+                    {data?.edit?.[r]?.[c].icon &&
+                      !inputField &&
+                      (c === 0 ? (
+                        <Tooltips
+                          color="dark"
+                          tooltipPlacement="bottom-start"
+                          tooltipText={data?.edit?.[r][c].inputValue ?? ''}
+                        >
+                          <HelpOutlineIcon
+                            sx={{
+                              fontSize: '18px',
+                              color: '#888888',
+                              cursor: 'pointer',
+                              '&:hover': {
+                                color: '#0088CC',
+                              },
+                            }}
+                          />
+                        </Tooltips>
+                      ) : (
+                        <span style={{ marginLeft: 'auto' }}>
+                          <EditIcon
+                            onClick={(e) => handleEditFn(e, r, c)}
+                            sx={{
+                              fontSize: '18px',
+                              color: '#888888',
+                              cursor: 'pointer',
+                              '&:hover': {
+                                color: '#0088CC',
+                              },
+                            }}
+                          />
+                        </span>
+                      ))}
                   </div>
                 </td>
               )

--- a/src/components/basic/Stepper/Stepper.stories.tsx
+++ b/src/components/basic/Stepper/Stepper.stories.tsx
@@ -33,12 +33,12 @@ const stepperElements = [
     step: 1,
     headline: 'App Market Card',
     text: 'Created',
-    color: '#B3CB2D'
+    color: '#B3CB2D',
   },
   {
     step: 2,
     headline: 'Contract & Consent',
-    color: '#0F71CB'
+    color: '#0F71CB',
   },
   {
     step: 3,

--- a/src/components/basic/Stepper/StepperItem.tsx
+++ b/src/components/basic/Stepper/StepperItem.tsx
@@ -66,7 +66,7 @@ export const StepperItem = ({
         width: `${width}%`,
         margin: '0px',
         borderBottom: `2px solid ${backgroundColor}`,
-        textAlign: 'center'
+        textAlign: 'center',
       }}
     >
       <Box
@@ -80,7 +80,7 @@ export const StepperItem = ({
           display: `${text ? 'inline-block' : 'flex'}`,
           padding: '3px 15px',
           justifyContent: 'center',
-          alignItems: 'center'
+          alignItems: 'center',
         }}
       >
         <Typography
@@ -92,22 +92,23 @@ export const StepperItem = ({
             width: 'fit-content',
           }}
         >
-          {done && (
-            text || <svg
-              width="14"
-              height="13"
-              viewBox="0 0 14 13"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                fillRule="evenodd"
-                clipRule="evenodd"
-                d="M13.8078 1.24939L5.09535 12.1399L0.305542 7.15056L1.74832 5.7655L4.95851 9.10944L12.2461 0L13.8078 1.24939Z"
-                fill="white"
-              />
-            </svg>
-          )}
+          {done &&
+            (text || (
+              <svg
+                width="14"
+                height="13"
+                viewBox="0 0 14 13"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  fillRule="evenodd"
+                  clipRule="evenodd"
+                  d="M13.8078 1.24939L5.09535 12.1399L0.305542 7.15056L1.74832 5.7655L4.95851 9.10944L12.2461 0L13.8078 1.24939Z"
+                  fill="white"
+                />
+              </svg>
+            ))}
           {!done && step}
         </Typography>
       </Box>

--- a/src/components/content/Cards/CardImage.tsx
+++ b/src/components/content/Cards/CardImage.tsx
@@ -36,6 +36,7 @@ export interface CardImageProps {
   imageShape?: CardImageShape
   imageLoader?: (src: string) => Promise<ArrayBuffer>
   preview?: boolean
+  imageElement?: JSX.Element
 }
 
 export const CardImage = ({
@@ -44,6 +45,7 @@ export const CardImage = ({
   imageShape = 'round',
   imageLoader,
   preview = false,
+  imageElement,
 }: CardImageProps) => {
   const { transitions } = useTheme()
   const withPreview = (size: number) => (preview ? size + 18 : size)
@@ -63,22 +65,28 @@ export const CardImage = ({
     },
   }
 
+  const style: React.CSSProperties = {
+    objectFit: 'cover',
+    transition: transitions.create(['all'], {
+      duration: transitions.duration.shorter,
+    }),
+    ...sx.image[imageSize],
+    ...(imageSize === 'small' && sx.image[imageShape]),
+    ...(imageSize === 'medium' && sx.image[imageShape]),
+  }
+
   return (
     <Box sx={sx.container[imageSize]}>
-      <Image
-        src={image?.src ?? LogoGrayData}
-        alt={image?.alt}
-        loader={imageLoader}
-        style={{
-          objectFit: 'cover',
-          transition: transitions.create(['all'], {
-            duration: transitions.duration.shorter,
-          }),
-          ...sx.image[imageSize],
-          ...(imageSize === 'small' && sx.image[imageShape]),
-          ...(imageSize === 'medium' && sx.image[imageShape]),
-        }}
-      />
+      {imageElement ? (
+        <div style={style}>{imageElement}</div>
+      ) : (
+        <Image
+          src={image?.src ?? LogoGrayData}
+          alt={image?.alt}
+          loader={imageLoader}
+          style={style}
+        />
+      )}
     </Box>
   )
 }


### PR DESCRIPTION
## Description

Enable custom image elements on cards

## Why

We also like to support the option to render already loaded images on cards.
Some formatted files also added.

## Issue

ref. Jira CPLP-3190

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
