### PR TITLE
feat(cards): add image element to cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.29
+
+- Add image element to cards
+
 ## 2.0.28
 
 - Enable JSX elements on cards

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catena-x/portal-shared-components",
-  "version": "2.0.28",
+  "version": "2.0.29",
   "description": "Catena-X Portal Shared Components",
   "author": "Catena-X Contributors",
   "license": "Apache-2.0",

--- a/src/components/content/Cards/index.tsx
+++ b/src/components/content/Cards/index.tsx
@@ -42,6 +42,7 @@ interface CardsProps {
   imageSize?: CardProps['imageSize']
   imageShape?: CardProps['imageShape']
   imageLoader?: CardProps['imageLoader']
+  imageElement?: CardProps['imageElement']
   columns?: number
   readMoreText?: CardProps['readMoreText']
   readMoreLink?: CardProps['readMoreLink']
@@ -68,6 +69,7 @@ export const Cards = ({
   imageSize,
   imageShape,
   imageLoader,
+  imageElement,
   columns = 6,
   expandOnHover,
   filledBackground,
@@ -95,6 +97,7 @@ export const Cards = ({
     imageSize,
     imageShape,
     imageLoader,
+    imageElement,
     expandOnHover,
     filledBackground,
     addButtonClicked,


### PR DESCRIPTION
## Description

Add an optional image element to cards

## Why

Developers can add an optional image item to cards.

## Issue

ref: Jira CPLP-3190

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally