### PR TITLE
fix(image): render image with loader when specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.23
+
+- Render images directly with loader when specified
+
 ## 2.1.22
 
 - Select list default value functionality fix

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catena-x/portal-shared-components",
-  "version": "2.1.22",
+  "version": "2.1.23",
   "description": "Catena-X Portal Shared Components",
   "author": "Catena-X Contributors",
   "license": "Apache-2.0",

--- a/src/components/basic/Image/index.tsx
+++ b/src/components/basic/Image/index.tsx
@@ -1,6 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021, 2023 BMW Group AG
- * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -69,13 +68,23 @@ export const Image = ({ src, alt, style, loader }: ImageProps): JSX.Element => {
     }
   }, [src, loader])
 
+  const renderByLoader = () => {
+    setLoad(true)
+    getData().catch((e) => {
+      setError(true)
+    })
+    return <img src={LogoGrayData} alt={alt ?? 'Catena-X'} />
+  }
+
   useEffect(() => {
     setError(false)
     setLoad(false)
     setData(src)
   }, [src])
 
-  return (
+  return loader ? (
+    renderByLoader()
+  ) : (
     <img
       src={!load && !error && src.startsWith('blob:') ? src : data}
       alt={alt ?? 'Catena-X'}


### PR DESCRIPTION
## Description

When an image loader is specified use it directly

## Why

When the image component has an image url and a loader specified it tries to display the image URL directly first and only in case of an error is using the loader which can result in a loading error plus delayed loading time. With this fix we always use the loader directly when one is specified.

## Issue

ref: Jira CPLP-3190

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
