### PR TITLE
fix(page loading): condition for more button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.27
+
+- fix more button issue in page loading component
+
 ## 2.1.26
 
 - added new quick links component

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catena-x/portal-shared-components",
-  "version": "2.1.28",
+  "version": "2.1.29",
   "description": "Catena-X Portal Shared Components",
   "author": "Catena-X Contributors",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catena-x/portal-shared-components",
-  "version": "2.1.26",
+  "version": "2.1.27",
   "description": "Catena-X Portal Shared Components",
   "author": "Catena-X Contributors",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catena-x/portal-shared-components",
-  "version": "2.1.27",
+  "version": "2.1.28",
   "description": "Catena-X Portal Shared Components",
   "author": "Catena-X Contributors",
   "license": "Apache-2.0",

--- a/src/components/basic/Table/PageLoadingTable.tsx
+++ b/src/components/basic/Table/PageLoadingTable.tsx
@@ -138,7 +138,7 @@ export const PageLoadingTable = function <Row, Args>({
         reload={refetch}
         {...props}
       />
-      {items.length > 0 && hasMore && (
+      {items.length > 0 && hasMore ? (
         <Box
           sx={{
             width: '100%',
@@ -150,6 +150,8 @@ export const PageLoadingTable = function <Row, Args>({
         >
           <LoadMoreButton label={loadLabel || 'load more'} onClick={nextPage} />
         </Box>
+      ) : (
+        <></>
       )}
     </>
   )

--- a/src/components/basic/Table/components/Helper/helper.ts
+++ b/src/components/basic/Table/components/Helper/helper.ts
@@ -36,11 +36,10 @@ export interface PageDataRows {
 
 export const hasMorePages = (data: PageDataProps) => {
   return (
-    (data.page && data.totalPages && data?.page < data?.totalPages - 1) ??
-    (data?.meta && data.meta.page < data.meta.totalPages - 1)
+    data?.meta && data.meta.page < data.meta.totalPages - 1
   )
 }
 
 export const getMaxRows = (data: PageDataRows) => {
-  return data?.totalElements ?? data?.meta?.totalElements ?? 0
+  return data?.meta?.totalElements ?? 0
 }


### PR DESCRIPTION
## Description

update the condition to show more button based on the data available

## Why

more button is not visible

## Issue

[#439](https://github.com/eclipse-tractusx/portal-frontend/issues/439)

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
