### PR TITLE
chore: remove CVE-2023-42282 and catenax-ng picture references

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@ Link to Github issue.
 
 Please delete options that are not relevant.
 
-- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
+- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
 - [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
 - [ ] I have created and linked IP issues or requested their creation by a committer
 - [ ] I have performed a self-review of my own code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.28
+
+- upgrade node-ip package (transitive dependency over @storybook/core-server) to remove CVE-2023-42282
+
 ## 2.1.27
 
 - fix quick links style

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.1.28
 
 - upgrade node-ip package (transitive dependency over @storybook/core-server) to remove CVE-2023-42282
+- remove catenax-ng picture references
 
 ## 2.1.27
 

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -406,7 +406,7 @@ npm/npmjs/-/inflight/1.0.6, ISC, approved, clearlydefined
 npm/npmjs/-/inherits/2.0.4, ISC, approved, clearlydefined
 npm/npmjs/-/internal-slot/1.0.5, MIT, approved, #7118
 npm/npmjs/-/interpret/1.4.0, MIT, approved, clearlydefined
-npm/npmjs/-/ip/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/ip/2.0.1, MIT, approved, #13289
 npm/npmjs/-/ipaddr.js/1.9.1, MIT, approved, clearlydefined
 npm/npmjs/-/is-absolute-url/3.0.3, MIT, approved, clearlydefined
 npm/npmjs/-/is-arguments/1.1.1, MIT, approved, clearlydefined

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catena-x/portal-shared-components",
-  "version": "2.1.27",
+  "version": "2.1.28",
   "description": "Catena-X Portal Shared Components",
   "author": "Catena-X Contributors",
   "license": "Apache-2.0",

--- a/src/components/basic/Image/Image.stories.tsx
+++ b/src/components/basic/Image/Image.stories.tsx
@@ -101,7 +101,7 @@ const drawing = ((): string => {
 
 export const FromURL: StoryObj<typeof Component> = {
   args: {
-    src: 'https://raw.githubusercontent.com/catenax-ng/tx-portal-assets/main/public/assets/images/logos/cx-short.svg',
+    src: 'https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/public/assets/images/logos/cx-short.svg',
     style,
   },
 }

--- a/src/components/content/DemoComponents/CardGrid.stories.tsx
+++ b/src/components/content/DemoComponents/CardGrid.stories.tsx
@@ -29,7 +29,7 @@ export default meta
 export const Default: StoryObj<typeof Component> = {
   args: {
     baseUrl:
-      'https://raw.githubusercontent.com/catenax-ng/tx-portal-assets/main/public/assets/',
+      'https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/public/assets/',
     align: 'center',
     provider: {
       detailsWithImageRow1: [

--- a/src/components/content/DemoComponents/FlexImages.stories.tsx
+++ b/src/components/content/DemoComponents/FlexImages.stories.tsx
@@ -29,7 +29,7 @@ export default meta
 export const Default: StoryObj<typeof Component> = {
   args: {
     baseUrl:
-      'https://raw.githubusercontent.com/catenax-ng/tx-portal-assets/main/public/assets/',
+      'https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/public/assets/',
     provider: {
       images: [
         '/images/content/teaser.png',

--- a/src/components/content/DemoComponents/GridImages.stories.tsx
+++ b/src/components/content/DemoComponents/GridImages.stories.tsx
@@ -29,7 +29,7 @@ export default meta
 export const Default: StoryObj<typeof Component> = {
   args: {
     baseUrl:
-      'https://raw.githubusercontent.com/catenax-ng/tx-portal-assets/main/public/assets/',
+      'https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/public/assets/',
     provider: {
       images: [
         '/images/content/teaser.png',

--- a/yarn.lock
+++ b/yarn.lock
@@ -6820,9 +6820,9 @@ interpret@^1.0.0:
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
 ip@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ip/-/ip-2.0.0.tgz#4cf4ab182fee2314c75ede1276f8c80b479936da"
-  integrity sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ip/-/ip-2.0.1.tgz#e8f3595d33a3ea66490204234b77636965307105"
+  integrity sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==
 
 ipaddr.js@1.9.1:
   version "1.9.1"


### PR DESCRIPTION
## Description

- upgrade node-ip package (transitive dependency over @storybook/core-server) to remove CVE-2023-42282
- remove catenax-ng picture references
- pr-template: fix link to contributing guidelines 

## Why

security and chores

## Issue

na

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own changes
