### PR TITLE
fix(main header): remove margintop to avoid overriding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.31
+
+- Remove margintop from main header to avoid overriding
+
 ## 2.1.30
 
 - Fix quick links interface

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catena-x/portal-shared-components",
-  "version": "2.1.30",
+  "version": "2.1.31",
   "description": "Catena-X Portal Shared Components",
   "author": "Catena-X Contributors",
   "license": "Apache-2.0",

--- a/src/components/basic/Headers/MainHeader/MainHeader.tsx
+++ b/src/components/basic/Headers/MainHeader/MainHeader.tsx
@@ -127,7 +127,6 @@ export const MainHeader = ({
       sx={{
         width: '100%',
         height: `${headerHeight}px`,
-        marginTop: `${-mainNavigationHeight}px`,
         position: 'relative',
         background: `linear-gradient(${backgroundstyle().direction}deg, ${
           backgroundstyle().colorFrom


### PR DESCRIPTION
## Description

Fixed header overriding issue

## Why

marginTop in Mainheader file overriding the back content

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/525

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
