### PR TITLE
fix(DropPreview): complete string escaping and encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.34
+
+- Fix incomplete string escaping and encoding in DropPreview
+
 ## 2.1.33
 
 - Fix quick links styles

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catena-x/portal-shared-components",
-  "version": "2.1.33",
+  "version": "2.1.34",
   "description": "Catena-X Portal Shared Components",
   "author": "Catena-X Contributors",
   "license": "Apache-2.0",

--- a/src/components/basic/Dropzone/components/DropPreview.tsx
+++ b/src/components/basic/Dropzone/components/DropPreview.tsx
@@ -84,8 +84,8 @@ export const DropPreview: FunctionComponent<DropPreviewProps> = ({
     numTotal: number
   }) => {
     const uploadProgress = translations.uploadProgess
-      .replace('%', numUploaded.toString())
-      .replace('%', numTotal.toString())
+      .replace(/%/g, encodeURIComponent(numUploaded.toString()))
+      .replace(/%/g, encodeURIComponent(numTotal.toString()))
 
     return (
       <Box sx={{ typography: 'label2' }}>


### PR DESCRIPTION
## Description

complete string escaping and encoding in DropPreview

## Why

security finding

## Issue

https://github.com/eclipse-tractusx/portal-cd/issues/197

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes
