### PR TITLE
fix(css): fix misspelled properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.38
+
+- Fix warning about misspelled css property
+
 ## 2.1.37
 
 - Fix multiselect search and selected items display issues

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catena-x/portal-shared-components",
-  "version": "2.1.37",
+  "version": "2.1.38",
   "description": "Catena-X Portal Shared Components",
   "author": "Catena-X Contributors",
   "license": "Apache-2.0",

--- a/src/components/content/Cards/Card.tsx
+++ b/src/components/content/Cards/Card.tsx
@@ -258,7 +258,7 @@ export const Card = ({
                 textAlign: 'center',
                 textDecoration: 'none',
                 padding: '50px 90px 20px 90px',
-                '-webkit-transform': 'rotate(45deg)',
+                transform: 'rotate(45deg)',
                 zIndex: 10,
                 background:
                   subscriptionStatus?.toLowerCase() === 'pending'

--- a/src/components/content/Cards/CardDecision.tsx
+++ b/src/components/content/Cards/CardDecision.tsx
@@ -60,7 +60,7 @@ export const CardDecision = ({
     <Box
       sx={{
         display: 'flex',
-        '-ms-flex-wrap': 'wrap',
+        msFlexWrap: 'wrap',
         flexWrap: 'wrap',
         justifyContent: 'center',
         marginRight: '-10px',

--- a/src/components/content/Cards/index.tsx
+++ b/src/components/content/Cards/index.tsx
@@ -111,7 +111,7 @@ export const Cards = ({
     <Box
       sx={{
         display: 'flex',
-        '-ms-flex-wrap': 'wrap',
+        msFlexWrap: 'wrap',
         flexWrap: 'wrap',
         marginRight: '-10px',
         marginLeft: '-10px',


### PR DESCRIPTION
## Description

Fixed properties written in kebap-case where camelCase is required

## Why

In the browser dev tools we got an ugly warning message which is removed now.

## Issue

n/a

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally