### PR TITLE
fix(image): use image loader first if specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.41
+
+- Use Image loader first if specified
+
 ## 2.1.40
 
 - Moved the docs from assets to the docs/storybook directory

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catena-x/portal-shared-components",
-  "version": "2.1.40",
+  "version": "2.1.41",
   "description": "Catena-X Portal Shared Components",
   "author": "Catena-X Contributors",
   "license": "Apache-2.0",

--- a/src/components/basic/Image/index.tsx
+++ b/src/components/basic/Image/index.tsx
@@ -50,44 +50,35 @@ interface ImageProps {
 }
 
 export const Image = ({ src, alt, style, loader }: ImageProps): JSX.Element => {
-  const [data, setData] = useState(src)
-  const [load, setLoad] = useState(false)
+  const [data, setData] = useState(LogoGrayData)
   const [error, setError] = useState(false)
 
   const getData = useCallback(async () => {
     try {
-      const buffer =
-        loader != null ? await loader(src) : await defaultFetchImage(src)
+      const buffer = await (loader ? loader(src) : defaultFetchImage(src))
       const firstByte = buf2hex(buffer.slice(0, 1))
       const first3Bytes = buf2hex(buffer.slice(0, 3))
       const imageType =
         IMAGE_TYPES[firstByte] ?? IMAGE_TYPES[first3Bytes] ?? 'image/*'
       setData(URL.createObjectURL(new Blob([buffer], { type: imageType })))
     } catch (e) {
-      setError(true)
+      setData(LogoGrayData)
     }
   }, [src, loader])
 
   useEffect(() => {
-    setError(false)
-    setLoad(false)
-    setData(src)
-  }, [src])
+    getData().catch(
+      (e) => { console.error(e) }
+    )
+  }, [getData])
 
   return (
     <img
-      src={!load && !error && src.startsWith('blob:') ? src : data}
+      src={loader ?? error ? data : src}
       alt={alt ?? 'Catena-X'}
-      onError={() => {
+      onError={(e) => {
+        setError(true)
         setData(LogoGrayData)
-        if (load) {
-          setError(true)
-        } else {
-          setLoad(true)
-          getData().catch((e) => {
-            setError(true)
-          })
-        }
       }}
       style={{
         objectFit: 'cover',


### PR DESCRIPTION
## Description

Use image loader first if specified

## Why

The image component always tried to display the src url first which resulted in a lot of failure messages on the console in case the src url needed authentication. Now the logic has been reversed and if a loader function is specified this will be invoked first. This reduces the number of request and the console looks cleaner.

## Issue

ref Jira: CPLP-3243, -3244, -3273

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally