### PR TITLE
fix(cards): add submenu options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.45
+
+- Add submenu options for active and inactive cards
+
 ## 2.1.44
 
 - UI Improvements in Card component. Add favourite icon and full length button

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catena-x/portal-shared-components",
-  "version": "2.1.44",
+  "version": "2.1.45",
   "description": "Catena-X Portal Shared Components",
   "author": "Catena-X Contributors",
   "license": "Apache-2.0",

--- a/src/components/basic/SortOption/index.tsx
+++ b/src/components/basic/SortOption/index.tsx
@@ -25,6 +25,7 @@ import { Box } from '@mui/material'
 export interface SortOptionsType {
   label: string
   value: string
+  disabled?: boolean
 }
 
 export const SortOption = ({
@@ -66,8 +67,10 @@ export const SortOption = ({
                 minWidth: '152px',
                 maxWidth: '220px',
                 borderRadius: '10px',
-                cursor: 'pointer',
+                cursor: entry?.disabled ? 'auto !important' : 'pointer',
                 listStyleType: 'none',
+                pointerEvents: entry?.disabled ? 'none' : 'initial',
+                opacity: entry?.disabled ? '0.5' : '1',
                 '&:hover': {
                   backgroundColor: 'rgba(15, 113, 203, 0.05)',
                 },

--- a/src/components/content/Cards/Card.tsx
+++ b/src/components/content/Cards/Card.tsx
@@ -64,7 +64,8 @@ export interface CardProps
     | undefined
   topValue?: number
   subMenu?: boolean
-  submenuOptions?: SubItems[]
+  activeSubmenuOptions?: SubItems[]
+  inactiveSubmenuOptions?: SubItems[]
   submenuClick?: (sortMenu: string, id: string | undefined) => undefined
   tooltipText?: string
   showStatus?: boolean
@@ -101,7 +102,8 @@ export const Card = ({
   positionValue,
   topValue = 0,
   subMenu,
-  submenuOptions,
+  activeSubmenuOptions,
+  inactiveSubmenuOptions,
   submenuClick,
   tooltipText = '',
   showStatus = true,
@@ -183,7 +185,10 @@ export const Card = ({
 
   const handleSubmenuFn = (e: React.MouseEvent) => {
     e.stopPropagation()
-    if (status?.toLowerCase() === 'active') {
+    if (
+      status?.toLowerCase() === 'active' ||
+      status?.toLowerCase() === 'inactive'
+    ) {
       setShowModal(true)
     }
   }
@@ -304,7 +309,10 @@ export const Card = ({
               color="dark"
               tooltipPlacement="bottom-start"
               tooltipText={
-                status?.toLowerCase() === 'active' ? '' : tooltipText
+                status?.toLowerCase() === 'active' ||
+                status?.toLowerCase() === 'inactive'
+                  ? ''
+                  : tooltipText
               }
               additionalStyles={{ marginLeft: '210px' }}
             >
@@ -319,12 +327,14 @@ export const Card = ({
                 <MoreVertIcon
                   sx={{
                     color:
-                      status?.toLowerCase() === 'active'
+                      status?.toLowerCase() === 'active' ||
+                      status?.toLowerCase() === 'inactive'
                         ? '#0F71CB'
                         : '#999999',
                     borderRadius: '15px',
                     cursor: 'pointer',
-                    ...(status?.toLowerCase() === 'active' && {
+                    ...((status?.toLowerCase() === 'active' ||
+                      status?.toLowerCase() === 'inactive') && {
                       ':hover': {
                         backgroundColor: 'rgb(176 206 235 / 40%)',
                       },
@@ -347,7 +357,7 @@ export const Card = ({
               margin: '-10px 80px',
             }}
           >
-            {submenuOptions && (
+            {activeSubmenuOptions && status?.toLowerCase() === 'active' && (
               <SortOption
                 show={showModal}
                 selectedOption={sortOption}
@@ -355,8 +365,20 @@ export const Card = ({
                   setSortOption(value)
                   setShowModal(false)
                 }}
-                sortOptions={submenuOptions}
-                singleMenu={submenuOptions?.length === 1}
+                sortOptions={activeSubmenuOptions}
+                singleMenu={activeSubmenuOptions?.length === 1}
+              />
+            )}
+            {inactiveSubmenuOptions && status?.toLowerCase() === 'inactive' && (
+              <SortOption
+                show={showModal}
+                selectedOption={sortOption}
+                setSortOption={(value: string) => {
+                  setSortOption(value)
+                  setShowModal(false)
+                }}
+                sortOptions={inactiveSubmenuOptions}
+                singleMenu={inactiveSubmenuOptions?.length === 1}
               />
             )}
           </div>

--- a/src/components/content/Cards/Card.tsx
+++ b/src/components/content/Cards/Card.tsx
@@ -193,6 +193,16 @@ export const Card = ({
     }
   }
 
+  const renderTooltipText = () => {
+    if (
+      status?.toLowerCase() === 'active' ||
+      status?.toLowerCase() === 'inactive'
+    ) {
+      return ''
+    } else {
+      return tooltipText
+    }
+  }
   return (
     <div
       ref={boxRef}
@@ -308,12 +318,7 @@ export const Card = ({
             <Tooltips
               color="dark"
               tooltipPlacement="bottom-start"
-              tooltipText={
-                status?.toLowerCase() === 'active' ||
-                status?.toLowerCase() === 'inactive'
-                  ? ''
-                  : tooltipText
-              }
+              tooltipText={renderTooltipText()}
               additionalStyles={{ marginLeft: '210px' }}
             >
               <Box

--- a/src/components/content/Cards/MarketplaceCard.stories.tsx
+++ b/src/components/content/Cards/MarketplaceCard.stories.tsx
@@ -102,11 +102,26 @@ const items = [
   },
 ]
 
-const submenuOptions = [
+const activeSubmenuOptions = [
   {
     label: 'Tab 1',
     value: 'tab1',
-    url: '/tab1',
+  },
+  {
+    label: 'Tab 2',
+    value: 'tab2',
+  },
+]
+const inactiveSubmenuOptions = [
+  {
+    label: 'Tab 1',
+    value: 'tab1',
+    disabled: true,
+  },
+  {
+    label: 'Tab 2',
+    value: 'tab2',
+    disabled: true,
   },
 ]
 
@@ -120,6 +135,7 @@ MarketplaceCard.args = {
   imageShape: 'round',
   addButtonClicked: false,
   subMenu: true,
-  submenuOptions: submenuOptions,
+  activeSubmenuOptions: activeSubmenuOptions,
+  inactiveSubmenuOptions: inactiveSubmenuOptions,
   tooltipText: 'Action is pending',
 }

--- a/src/components/content/Cards/index.tsx
+++ b/src/components/content/Cards/index.tsx
@@ -52,7 +52,8 @@ interface CardsProps {
   onNewCardButton?: React.MouseEventHandler | undefined
   onCardClick?: (item: CardItems) => void
   subMenu?: boolean
-  submenuOptions?: SubItems[]
+  activeSubmenuOptions?: SubItems[]
+  inactiveSubmenuOptions?: SubItems[]
   submenuClick?: (sortMenu: string, id: string | undefined) => undefined
   tooltipText?: string
   showStatus?: boolean
@@ -81,7 +82,8 @@ export const Cards = ({
     // empty
   },
   subMenu = false,
-  submenuOptions = [],
+  activeSubmenuOptions = [],
+  inactiveSubmenuOptions = [],
   submenuClick = (sortMenu: string, id: string | undefined) => {
     // empty
   },
@@ -102,7 +104,8 @@ export const Cards = ({
     filledBackground,
     addButtonClicked,
     subMenu,
-    submenuOptions,
+    activeSubmenuOptions,
+    inactiveSubmenuOptions,
     submenuClick,
     tooltipText,
     showStatus,


### PR DESCRIPTION
## Description

Added submenu options for active and inactive cards

## Why

To enhance inactive cards with submenu

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/581

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
