### PR TITLE
fix(types): generate types for typescript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.1
+
+- Generate typescript types to build
+
 ## 3.0.0
 
 - Switch build framework from CRA to VITE

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catena-x/portal-shared-components",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Catena-X Portal Shared Components",
   "author": "Catena-X Contributors",
   "license": "Apache-2.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
     react(),
     libInjectCss(),
     dts({
-      include: ['lib'],
+      include: ['src'],
       exclude: ['**/*.stories.tsx', '**/*.test.tsx'],
     }),
   ],


### PR DESCRIPTION
## Description

Generate .d.ts files for use in typescript

## Why

Due to a recent rename of the src folder the typescript definition files were not generated correctly.

## Issue

n/a

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally