### PR TITLE
chore: remove eclipse dash tool jar

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -42,8 +42,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
 
+      - name: Download Eclipse Dash Tool
+        run: curl -L --output ./org.eclipse.dash.licenses.jar 'https://repo.eclipse.org/service/local/artifact/maven/redirect?r=dash-licenses&g=org.eclipse.dash&a=org.eclipse.dash.licenses&v=LATEST'
+
       - name: Generate Dependencies file
-        run: java -jar ./scripts/download/org.eclipse.dash.licenses-1.1.1.jar yarn.lock -project automotive.tractusx -summary DEPENDENCIES || true
+        run: java -jar ./org.eclipse.dash.licenses.jar yarn.lock -project automotive.tractusx -summary DEPENDENCIES || true
 
       - name: Check if dependencies were changed
         id: dependencies-changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.2
+
+- Remove eclipse dash tool jar: add step to dependencies check to download eclipse dash tool instead
+
 ## 3.0.1
 
 - Generate typescript types to build
@@ -14,7 +18,7 @@
 
 ## 2.1.44
 
-- UI Improvements in Card component. Add favourite icon and full length button
+- UI Improvements in Card component. Add favorite icon and full length button
 
 ## 2.1.43
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catena-x/portal-shared-components",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Catena-X Portal Shared Components",
   "author": "Catena-X Contributors",
   "license": "Apache-2.0",

--- a/scripts/check-dependencies.md
+++ b/scripts/check-dependencies.md
@@ -1,9 +1,0 @@
-# Check dependencies
-
-Dependencies are checked by the [Eclipse Dash License Tool](https://github.com/eclipse/dash-licenses) with a GitHub workflow (dependencies.yaml).
-
-This workflow uses the executable jar in the download directory.
-
-In order to update the executable jar run the following command from the root directory:
-
-    curl -L --output ./scripts/download/org.eclipse.dash.licenses-1.1.1.jar 'https://repo.eclipse.org/service/local/artifact/maven/redirect?r=dash-licenses&g=org.eclipse.dash&a=org.eclipse.dash.licenses&v=LATEST'


### PR DESCRIPTION
## Description

add step to dependencies check to download eclipse dash tool instead

## Why

the jar leads continuously to an unnecessary long IP check, example https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/14240

## Issue

na

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own changes
