### PR TITLE
fix(compatibility): re-introduce props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.3
+
+- Re-introduce some props for backward compatibility
+
 ## 3.0.2
 
 - Remove eclipse dash tool jar: add step to dependencies check to download eclipse dash tool instead

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catena-x/portal-shared-components",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Catena-X Portal Shared Components",
   "author": "Catena-X Contributors",
   "license": "Apache-2.0",
@@ -91,10 +91,10 @@
     "pretty": "prettier --write \"**/*.{ts,tsx,js,jsx,json,css,sass,scss,xml,md}\"",
     "test": "jest",
     "test:ci": "CI=true jest",
+    "start": "yarn start:storybook",
     "start:dev": "vite",
     "start:storybook": "storybook dev -p 3006",
     "build:storybook": "storybook build -o ./storybook",
-    "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "storybook": "storybook dev -p 6006"
   }
 }

--- a/src/components/content/Cards/CardHorizontal.tsx
+++ b/src/components/content/Cards/CardHorizontal.tsx
@@ -31,10 +31,12 @@ interface CardHorizontalProps extends CardChipProps {
   subTitle?: string
   borderRadius: number
   imagePath: string
+  imageAlt?: string
   description?: string
   backgroundColor?: string
   buttonText?: string
   onBtnClick?: React.MouseEventHandler
+  expandOnHover?: boolean
 }
 
 export const CardHorizontal = ({
@@ -43,10 +45,18 @@ export const CardHorizontal = ({
   subTitle,
   borderRadius = 0,
   imagePath,
+  // @ts-expect-error keep for backward compatibility
+  imageAlt,
   description,
+  // @ts-expect-error keep for backward compatibility
+  status,
+  // @ts-expect-error keep for backward compatibility
+  statusText,
   buttonText,
   onBtnClick,
   backgroundColor,
+  // @ts-expect-error keep for backward compatibility
+  expandOnHover = false,
 }: CardHorizontalProps) => {
   const theme = useTheme()
   const boxRef = useRef<HTMLDivElement>(null)

--- a/src/components/content/Cards/index.tsx
+++ b/src/components/content/Cards/index.tsx
@@ -43,16 +43,18 @@ interface CardsProps {
   imageShape?: CardProps['imageShape']
   imageLoader?: CardProps['imageLoader']
   imageElement?: CardProps['imageElement']
+  columns?: number
   readMoreText?: CardProps['readMoreText']
   readMoreLink?: CardProps['readMoreLink']
   addButtonClicked?: boolean
+  showAddNewCard?: boolean
   newButtonText?: string
   onNewCardButton?: React.MouseEventHandler
   onCardClick?: (item: CardItems) => void
   subMenu?: boolean
   activeSubmenuOptions?: SubItems[]
   inactiveSubmenuOptions?: SubItems[]
-  submenuClick?: (sortMenu: string, id: string | undefined) => undefined
+  submenuClick?: (sortMenu: string, id?: string) => undefined
   tooltipText?: string
   showStatus?: boolean
   status?: string
@@ -69,9 +71,13 @@ export const Cards = ({
   imageSize,
   imageShape,
   imageLoader,
+  // @ts-expect-error keep for backward compatibility
+  columns = 6,
   expandOnHover,
   filledBackground,
   addButtonClicked = false,
+  // @ts-expect-error keep for backward compatibility
+  showAddNewCard = false,
   newButtonText,
   onNewCardButton,
   onCardClick = () => {


### PR DESCRIPTION
## Description

Keep some props removed during framework upgrade

## Why

During the framework upgrade some props were removed after the typescript compiler showed them as obsolete. However we keep them for backward compatibility

## Issue

#147 

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally