### PR TITLE
fix(sub navigation): show sub navigation contents on mouse hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.8
+
+- Show sub navigation contents to the user on mouse hover
+
 ## 3.0.7
 
 - Upgrade dependencies

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catena-x/portal-shared-components",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "Catena-X Portal Shared Components",
   "author": "Catena-X Contributors",
   "license": "Apache-2.0",

--- a/src/components/basic/NewSubNavigation/index.tsx
+++ b/src/components/basic/NewSubNavigation/index.tsx
@@ -79,89 +79,91 @@ export const NewSubNavigation = ({
               >
                 {header}
               </Typography>
-              <Box className="navigationOverlay">
-                {navigationArray?.map((link: NavigationItem) => {
-                  return (
-                    <Box
-                      key={link.index}
-                      onClick={() => {
-                        onClick(link.navigation)
-                        setShow(!show)
-                        if (updateHeaderTitle) {
-                          setHeader(link.title)
-                        }
-                      }}
-                      className="navigationOverlayItem"
-                      onMouseOut={() => {
-                        setHighlight(link.title)
-                      }}
-                      onMouseOver={() => {
-                        // do nothing
-                      }}
-                      sx={{
-                        backgroundColor:
-                          header === link.title || highlight === link.title
-                            ? 'rgba(15, 113, 203, 0.05)'
-                            : 'transparent',
-                      }}
-                    >
-                      <EastIcon
-                        sx={{
-                          marginRight: '16px',
-                          fontSize: '18px',
-                          color:
-                            header === link.title || highlight === link.title
-                              ? '#0f71cb'
-                              : '#EAF1FE',
-                        }}
-                      />
-                      <Typography
-                        variant="h4"
-                        sx={{
-                          color:
-                            header === link.title || highlight === link.title
-                              ? '#111111'
-                              : '#888888',
-                          fontSize: '14px',
-                          textTransform: 'lowercase',
-                        }}
-                      >
-                        {link.title}
-                      </Typography>
-                    </Box>
-                  )
-                })}
-                {buttonArray?.length > 1 && (
-                  <Divider
-                    sx={{
-                      margin: '10px 0px',
-                      borderWidth: '1px',
-                      width: '100%',
-                    }}
-                  />
-                )}
-                {buttonArray?.length > 1 &&
-                  buttonArray?.map((btn: NavigationButton) => {
+              {show && (
+                <Box className="navigationOverlay">
+                  {navigationArray?.map((link: NavigationItem) => {
                     return (
-                      <Button
-                        key={btn.buttonLabel}
-                        onClick={(e) => {
-                          btn.onButtonClick(e)
+                      <Box
+                        key={link.index}
+                        onClick={() => {
+                          onClick(link.navigation)
                           setShow(!show)
+                          if (updateHeaderTitle) {
+                            setHeader(link.title)
+                          }
                         }}
-                        color="secondary"
-                        variant="outlined"
-                        size="small"
+                        className="navigationOverlayItem"
+                        onMouseOut={() => {
+                          setHighlight(link.title)
+                        }}
+                        onMouseOver={() => {
+                          // do nothing
+                        }}
                         sx={{
-                          marginTop: '10px',
-                          textTransform: 'lowercase',
+                          backgroundColor:
+                            header === link.title || highlight === link.title
+                              ? 'rgba(15, 113, 203, 0.05)'
+                              : 'transparent',
                         }}
                       >
-                        {btn.buttonLabel}
-                      </Button>
+                        <EastIcon
+                          sx={{
+                            marginRight: '16px',
+                            fontSize: '18px',
+                            color:
+                              header === link.title || highlight === link.title
+                                ? '#0f71cb'
+                                : '#EAF1FE',
+                          }}
+                        />
+                        <Typography
+                          variant="h4"
+                          sx={{
+                            color:
+                              header === link.title || highlight === link.title
+                                ? '#111111'
+                                : '#888888',
+                            fontSize: '14px',
+                            textTransform: 'lowercase',
+                          }}
+                        >
+                          {link.title}
+                        </Typography>
+                      </Box>
                     )
                   })}
-              </Box>
+                  {buttonArray?.length > 1 && (
+                    <Divider
+                      sx={{
+                        margin: '10px 0px',
+                        borderWidth: '1px',
+                        width: '100%',
+                      }}
+                    />
+                  )}
+                  {buttonArray?.length > 1 &&
+                    buttonArray?.map((btn: NavigationButton) => {
+                      return (
+                        <Button
+                          key={btn.buttonLabel}
+                          onClick={(e) => {
+                            btn.onButtonClick(e)
+                            setShow(!show)
+                          }}
+                          color="secondary"
+                          variant="outlined"
+                          size="small"
+                          sx={{
+                            marginTop: '10px',
+                            textTransform: 'lowercase',
+                          }}
+                        >
+                          {btn.buttonLabel}
+                        </Button>
+                      )
+                    })}
+                </Box>
+              )}
             </Box>
             {buttonArray?.length === 1 && (
               <Button


### PR DESCRIPTION
## Description

show sub navigation to the user on hover to the dots/sub navigation header title

## Why

sub navigation is blocking user to access other section in smaller browser

## Issue

#759

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
