### PR TITLE
fix(vertical table): fixed editing input field in vertical table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.10
+
+- Fixed editing input field in vertical table
+
 ## 3.0.9
 
 - Add copy icon and functionality to horizontal table

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catena-x/portal-shared-components",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "description": "Catena-X Portal Shared Components",
   "author": "Catena-X Contributors",
   "license": "Apache-2.0",

--- a/src/components/basic/StaticTable/VerticalTable.tsx
+++ b/src/components/basic/StaticTable/VerticalTable.tsx
@@ -72,7 +72,7 @@ export const VerticalTable = ({
             onChange={(e) => {
               addInputValue(e.target.value, row, column)
             }}
-            onKeyPress={(event) => {
+            onKeyDown={(event) => {
               if (event.key === 'Enter' && !inputErrorMessage) {
                 setInputField(null)
                 if (handleEdit) handleEdit(inputValue)
@@ -111,9 +111,6 @@ export const VerticalTable = ({
     <table
       style={{ width: '100%', borderCollapse: 'collapse' }}
       onClick={() => {
-        setInputField(null)
-      }}
-      onKeyDown={() => {
         setInputField(null)
       }}
     >

--- a/src/components/basic/StaticTable/VerticalTable.tsx
+++ b/src/components/basic/StaticTable/VerticalTable.tsx
@@ -72,7 +72,7 @@ export const VerticalTable = ({
             onChange={(e) => {
               addInputValue(e.target.value, row, column)
             }}
-            onKeyDown={(event) => {
+            onKeyPress={(event) => {
               if (event.key === 'Enter' && !inputErrorMessage) {
                 setInputField(null)
                 if (handleEdit) handleEdit(inputValue)
@@ -112,6 +112,9 @@ export const VerticalTable = ({
       style={{ width: '100%', borderCollapse: 'collapse' }}
       onClick={() => {
         setInputField(null)
+      }}
+      onKeyDown={() => {
+        // do nothing
       }}
     >
       <thead>


### PR DESCRIPTION
## Description

Fixed editing input field in vertical table

## Why

 To make editing the input field possible in vertical table,

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/775

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
