### PR TITLE
feat(custom accordion): change background color on hover and focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.10
+
+- Change background color on hover and focus in custom accordion
+
 ## 3.0.9
 
 - Add copy icon and functionality to horizontal table

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catena-x/portal-shared-components",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "description": "Catena-X Portal Shared Components",
   "author": "Catena-X Contributors",
   "license": "Apache-2.0",

--- a/src/components/basic/CustomAccordion/Item.tsx
+++ b/src/components/basic/CustomAccordion/Item.tsx
@@ -67,11 +67,11 @@ export const CustomAccordionItem = ({
         sx={{
           bgcolor: color,
           ':hover': {
-            bgcolor: 'background.background12',
+            bgcolor: color ?? 'background.background12',
           },
           ':focus': {
             boxShadow: 'none !important',
-            bgcolor: 'background.background12',
+            bgcolor: color ?? 'background.background12',
           },
         }}
       >


### PR DESCRIPTION
## Description

Change background color on hover and focus

## Why

If color exists then it should take given color otherwise default color will be assigned on hover/focus

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/803

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally