### PR TITLE
fix(static table): fix copy icon color 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.12
+
+- Change default color and on hover color of copy icon in static table
+
 ## 3.0.11
 
 - Change background color on hover and focus in custom accordion

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catena-x/portal-shared-components",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "description": "Catena-X Portal Shared Components",
   "author": "Catena-X Contributors",
   "license": "Apache-2.0",

--- a/src/components/basic/StaticTable/HorizontalTable.tsx
+++ b/src/components/basic/StaticTable/HorizontalTable.tsx
@@ -45,9 +45,9 @@ export const HorizontalTable = ({ data }: { data: TableType }) => {
           cursor: 'pointer',
           display: 'inline-flex',
           float: 'right',
-          color: copied === copyData?.copyValue ? '#00cc00' : '#eeeeee',
+          color: copied === copyData?.copyValue ? '#00cc00' : '#888888',
           ':hover': {
-            color: copied === copyData?.copyValue ? '#00cc00' : '#cccccc',
+            color: copied === copyData?.copyValue ? '#00cc00' : '#0088CC',
           },
           width: 'max-width',
         }}

--- a/src/components/basic/StaticTable/VerticalTable.tsx
+++ b/src/components/basic/StaticTable/VerticalTable.tsx
@@ -183,12 +183,12 @@ export const VerticalTable = ({
                           color:
                             copied === data?.edit?.[r]?.[c].copyValue
                               ? '#00cc00'
-                              : '#eeeeee',
+                              : '#888888',
                           ':hover': {
                             color:
                               copied === data?.edit?.[r]?.[c].copyValue
                                 ? '#00cc00'
-                                : '#cccccc',
+                                : '#0088CC',
                           },
                         }}
                         onClick={() => {


### PR DESCRIPTION
## Description

Change default color and on hover color of copy icon in static table

## Why

To enhance the look and feel of the copy icon in static table

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
