### PR TITLE
feat(status tag): update status tag color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.29
+
+- updated status tag color and also updated theme and chip with 'deleted' property
+
 ## 3.0.28
 
 - updated unrestricted packages suggested by dependabot

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catena-x/portal-shared-components",
-  "version": "3.0.28",
+  "version": "3.0.29",
   "description": "Catena-X Portal Shared Components",
   "author": "Catena-X Contributors",
   "license": "Apache-2.0",

--- a/src/@types/chip.ts
+++ b/src/@types/chip.ts
@@ -26,5 +26,6 @@ declare module '@mui/material/Chip' {
     confirmed: true
     declined: true
     label: true
+    deleted: true
   }
 }

--- a/src/@types/styles.ts
+++ b/src/@types/styles.ts
@@ -161,6 +161,7 @@ declare module '@mui/material/styles' {
     confirmed: TypeChipColor
     declined: TypeChipColor
     label: TypeChipColor
+    deleted: TypeChipColor
     chip: TypeChipCardColor
     stepper: TypeStepper
     buttons: ButtonColor
@@ -180,6 +181,7 @@ declare module '@mui/material/styles' {
     confirmed?: Partial<TypeChipColor>
     declined?: Partial<TypeChipColor>
     label?: Partial<TypeChipColor>
+    deleted?: Partial<TypeChipColor>
     chip?: Partial<TypeChipCardColor>
     stepper?: Partial<TypeStepper>
     buttons?: Partial<ButtonColor>

--- a/src/components/basic/Table/components/StatusTag/index.tsx
+++ b/src/components/basic/Table/components/StatusTag/index.tsx
@@ -23,7 +23,7 @@ import MuiChip, {
 } from '@mui/material/Chip'
 
 interface StatusChipProps extends Omit<MuiStatusChipProps, 'color'> {
-  color?: 'pending' | 'confirmed' | 'declined' | 'label'
+  color?: 'pending' | 'confirmed' | 'declined' | 'label' | 'deleted'
 }
 
 export const StatusTag = ({

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -182,6 +182,10 @@ export const paletteDefinitions = {
     main: '#F2F3FB',
     contrastText: '#676BC6',
   },
+  deleted: {
+    main: '#eaeaea',
+    contrastText: '#adadad',
+  },
   info: {
     main: '#F2F3FB',
     contrastText: '#676BC6',


### PR DESCRIPTION
## Description

updated status tag color and also updated theme and chip with 'deleted' property

## Why

To add color for status 'deleted'

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/944

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally