### PR TITLE
fix: Resolve App details image duplications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
 - **chor:** run pretty explicitly ([702a9dc](https://github.com/eclipse-tractusx/portal-shared-components/commit/702a9dc7ca0ef003593ec5ad0ddf8459d92320f2))
 - **chor:** update deoendency file ([bb45f76](https://github.com/eclipse-tractusx/portal-shared-components/commit/bb45f761102e442fd727b10f5a1d0362a0f124cf))
 - **chro:** update the package version ([506dc70](https://github.com/eclipse-tractusx/portal-shared-components/commit/506dc709a28e19cbfc2dd6ea38f3af60ed3ef74c))
-- **ImageGallery:** Resolve duplicates image issue ([#288](https://github.com/eclipse-tractusx/portal-shared-components/issues/288))
 
 ## [3.3.0](https://github.com/eclipse-tractusx/portal-shared-components/compare/v3.2.0...v3.3.0) (2024-08-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - **chor:** run pretty explicitly ([702a9dc](https://github.com/eclipse-tractusx/portal-shared-components/commit/702a9dc7ca0ef003593ec5ad0ddf8459d92320f2))
 - **chor:** update deoendency file ([bb45f76](https://github.com/eclipse-tractusx/portal-shared-components/commit/bb45f761102e442fd727b10f5a1d0362a0f124cf))
 - **chro:** update the package version ([506dc70](https://github.com/eclipse-tractusx/portal-shared-components/commit/506dc709a28e19cbfc2dd6ea38f3af60ed3ef74c))
+- **ImageGallery:** Resolve duplicates image issue ([#288](https://github.com/eclipse-tractusx/portal-shared-components/issues/288))
 
 ## [3.3.0](https://github.com/eclipse-tractusx/portal-shared-components/compare/v3.2.0...v3.3.0) (2024-08-23)
 

--- a/src/components/basic/ImageGallery/index.tsx
+++ b/src/components/basic/ImageGallery/index.tsx
@@ -54,8 +54,8 @@ export const ImageGallery = ({
 
   const getIsInfinite = () => {
     if (mobile) return gallery?.length > 1
-    else if (tab) return gallery?.length > 2
-    else return gallery?.length > 3
+    if (tab) return gallery?.length > 2
+    return gallery?.length > 3
   }
 
   return (

--- a/src/components/basic/ImageGallery/index.tsx
+++ b/src/components/basic/ImageGallery/index.tsx
@@ -52,6 +52,12 @@ export const ImageGallery = ({
     else return 3
   }
 
+  const getIsInfinite = () => {
+    if (mobile) return gallery?.length > 1
+    else if (tab) return gallery?.length > 2
+    else return gallery?.length > 3
+  }
+
   return (
     <div className="cx-image-gallery">
       {hovered && hoveredImage?.url && (
@@ -68,7 +74,7 @@ export const ImageGallery = ({
         gapBetweenSlides={32}
         gapCarouselTop={0}
         dots={false}
-        infinite
+        infinite={getIsInfinite()}
         itemHeight={maxHeight ?? 0}
         itemWidth={maxWidth ?? 266}
         slidesToShow={getSlidesToShow()}


### PR DESCRIPTION
## Description

- The user uploads one image on the App details page while registering the app but it ended up showing the same image 3 times. Since max 3 images can be uploaded, the system somehow repeats the image thrice.
- One single image repeat thrice on the Validate & Publish screen as well as on the App overview page.

## Why

- Image should display only once on both the Validate & Publish screen as well as on the App overview page.

## Issue

- Shared Component: [#288](https://github.com/eclipse-tractusx/portal-shared-components/issues/288)
- Portal Frontend: [#1031](https://github.com/eclipse-tractusx/portal-frontend/issues/1031)

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas

![image](https://github.com/user-attachments/assets/f7b1f796-77a2-4893-bd0d-aee21ac77575)

