### PR TITLE
fix: Fix 401 Unauthorized Error on App Image Click in App Details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - **chor:** update deoendency file ([bb45f76](https://github.com/eclipse-tractusx/portal-shared-components/commit/bb45f761102e442fd727b10f5a1d0362a0f124cf))
 - **chro:** update the package version ([506dc70](https://github.com/eclipse-tractusx/portal-shared-components/commit/506dc709a28e19cbfc2dd6ea38f3af60ed3ef74c))
 
+- **ImageGallery:** Fix 401 Unauthorized error when clicking on App Images ([#291](https://github.com/eclipse-tractusx/portal-shared-components/issues/291))
+
 ## [3.3.0](https://github.com/eclipse-tractusx/portal-shared-components/compare/v3.2.0...v3.3.0) (2024-08-23)
 
 ### Features

--- a/src/components/basic/ImageGallery/ImageItemOverlay.tsx
+++ b/src/components/basic/ImageGallery/ImageItemOverlay.tsx
@@ -36,6 +36,7 @@ export default function ImageItemOverlay({
   text,
   modalWidth = '600',
   onClose,
+  loader,
 }: ImageType & ImageItemOverlayProps) {
   const { palette } = useTheme()
   return (
@@ -75,6 +76,7 @@ export default function ImageItemOverlay({
             <Image
               src={url}
               alt={text}
+              loader={loader}
               style={{
                 width: '100%',
                 height: '100%',

--- a/src/components/basic/ImageGallery/index.tsx
+++ b/src/components/basic/ImageGallery/index.tsx
@@ -61,6 +61,7 @@ export const ImageGallery = ({
           }}
           url={hoveredImage.url}
           text={hoveredImage.text}
+          loader={hoveredImage.loader}
           modalWidth={modalWidth}
         />
       )}


### PR DESCRIPTION
## Description
- This PR addresses the issue where clicking on app images in the "App Details" page results in a `401 Unauthorized` error.
- **Bug Fix:** Resolved the `401 Unauthorized` error that occurred when users clicked on app images in the "App Details" page.

## Why
- This issue was causing unauthorized errors, disrupting the user experience. Fixing this will ensure that users can interact with app images without encountering access issues.

## Issue

[#291
](https://github.com/eclipse-tractusx/portal-shared-components/issues/291)

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas

![image](https://github.com/user-attachments/assets/26a0a72c-48d2-4286-82c8-c917ba981066)

