### PR TITLE
fix(carousel): handle infinite scroll with a single child element

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -811,7 +811,7 @@ npm/npmjs/@babel/helper-wrap-function/7.25.0, MIT, approved, clearlydefined
 npm/npmjs/@babel/helpers/7.25.0, MIT, approved, clearlydefined
 npm/npmjs/@babel/highlight/7.24.7, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13941
 npm/npmjs/@babel/parser/7.24.8, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13492
-npm/npmjs/@babel/parser/7.25.3, MIT, approved, clearlydefined
+npm/npmjs/@babel/parser/7.25.3, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #16041
 npm/npmjs/@babel/plugin-bugfix-firefox-class-in-computed-class-key/7.25.3, MIT, approved, clearlydefined
 npm/npmjs/@babel/plugin-bugfix-safari-class-field-initializer-scope/7.25.0, MIT, approved, clearlydefined
 npm/npmjs/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.25.0, MIT, approved, clearlydefined
@@ -915,7 +915,7 @@ npm/npmjs/@babel/template/7.24.7, MIT, approved, clearlydefined
 npm/npmjs/@babel/template/7.25.0, MIT, approved, clearlydefined
 npm/npmjs/@babel/traverse/7.24.8, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13926
 npm/npmjs/@babel/traverse/7.25.3, MIT, approved, clearlydefined
-npm/npmjs/@babel/types/7.25.2, MIT, approved, clearlydefined
+npm/npmjs/@babel/types/7.25.2, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #16040
 npm/npmjs/@base2/pretty-print-object/1.0.1, BSD-2-Clause, approved, clearlydefined
 npm/npmjs/@bcoe/v8-coverage/0.2.3, ISC AND MIT, approved, clearlydefined
 npm/npmjs/@chromatic-com/storybook/1.6.1, MIT AND (BSD-2-Clause AND ISC AND MIT), approved, #15710

--- a/src/components/basic/Carousel/index.tsx
+++ b/src/components/basic/Carousel/index.tsx
@@ -75,7 +75,7 @@ export const Carousel = ({
 }: CarouselProps) => {
   const [showArrows, setShowArrows] = useState(false)
   const onMouseEnter = () => {
-    setShowArrows(true)
+    setShowArrows(true && arrayChildren.length > 1)
   }
   const onMouseLeave = () => {
     setShowArrows(false)
@@ -155,7 +155,9 @@ export const Carousel = ({
 
   const settings = {
     dots,
-    infinite,
+    // @ref https://github.com/akiran/react-slick/issues/2093#issuecomment-1705213915
+    // Prevents broken UI by defaulting infinite scroll to false when only a single child element is present.
+    infinite: infinite && arrayChildren.length > 1,
     slidesToShow: responsiveSlides,
     slidesToScroll: responsiveSlides,
     swipeToSlide: false,

--- a/src/components/basic/Carousel/index.tsx
+++ b/src/components/basic/Carousel/index.tsx
@@ -75,7 +75,7 @@ export const Carousel = ({
 }: CarouselProps) => {
   const [showArrows, setShowArrows] = useState(false)
   const onMouseEnter = () => {
-    setShowArrows(true && arrayChildren.length > 1)
+    setShowArrows(arrayChildren.length > 1)
   }
   const onMouseLeave = () => {
     setShowArrows(false)


### PR DESCRIPTION
## Description

Component: Carousel
- Modified the infinite setting, in case of single children is passed into component.

## Why

The carousel component is rendering incorrect UI with cloned elements when
-  `infiniteScroll` is set to `true` &
-  Single child element is passed

## Issue

#292 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have commented my code, particularly in hard-to-understand areas
