### PR TITLE
fix: updated deprecated type usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,12 @@
 
 ## [3.5.1](https://github.com/eclipse-tractusx/portal-shared-components/compare/v3.5.0...v3.5.1) (2024-09-05)
 
-
 ### Bug Fixes
 
-* **chor:** pretty ([b8c5264](https://github.com/eclipse-tractusx/portal-shared-components/commit/b8c5264ec5d442bd8d06459b7347e5591c1d8c7b))
-* **chor:** update version number ([3f03f0e](https://github.com/eclipse-tractusx/portal-shared-components/commit/3f03f0e8a01dcce597e6916fd8c882f630d5a490))
-* **table:** add new props to support multiple buttons in table component ([e0e7271](https://github.com/eclipse-tractusx/portal-shared-components/commit/e0e72713bc00523dcb11e0810c97ab702c6b87af))
-* **table:** support buttons props ([9ea1295](https://github.com/eclipse-tractusx/portal-shared-components/commit/9ea12951b17a737332b25018e10d78517cba499f))
+- **chor:** pretty ([b8c5264](https://github.com/eclipse-tractusx/portal-shared-components/commit/b8c5264ec5d442bd8d06459b7347e5591c1d8c7b))
+- **chor:** update version number ([3f03f0e](https://github.com/eclipse-tractusx/portal-shared-components/commit/3f03f0e8a01dcce597e6916fd8c882f630d5a490))
+- **table:** add new props to support multiple buttons in table component ([e0e7271](https://github.com/eclipse-tractusx/portal-shared-components/commit/e0e72713bc00523dcb11e0810c97ab702c6b87af))
+- **table:** support buttons props ([9ea1295](https://github.com/eclipse-tractusx/portal-shared-components/commit/9ea12951b17a737332b25018e10d78517cba499f))
 
 ## [3.5.0](https://github.com/eclipse-tractusx/portal-shared-components/compare/v3.4.0...v3.5.0) (2024-09-03)
 

--- a/src/components/basic/Alert/Alert.stories.tsx
+++ b/src/components/basic/Alert/Alert.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type StoryFn } from '@storybook/react'
-
 import { Alert as Component } from '.'
 
 export default {

--- a/src/components/basic/Alert/Alert.stories.tsx
+++ b/src/components/basic/Alert/Alert.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { Alert as Component } from '.'
 
@@ -31,7 +31,7 @@ export default {
   },
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args}>{args.children}</Component>
 

--- a/src/components/basic/BaseImage/BaseImage.stories.tsx
+++ b/src/components/basic/BaseImage/BaseImage.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type StoryFn } from '@storybook/react'
-
 import { BaseImage as Component } from '.'
 
 export default {

--- a/src/components/basic/BaseImage/BaseImage.stories.tsx
+++ b/src/components/basic/BaseImage/BaseImage.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { BaseImage as Component } from '.'
 
@@ -28,7 +28,7 @@ export default {
   tags: ['autodocs'],
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/Breadcrumb/Breadcrumb.stories.tsx
+++ b/src/components/basic/Breadcrumb/Breadcrumb.stories.tsx
@@ -20,7 +20,6 @@
 
 import { Link, Typography } from '@mui/material'
 import { type StoryFn } from '@storybook/react'
-
 import { Breadcrumb as Component } from '.'
 
 export default {

--- a/src/components/basic/Breadcrumb/Breadcrumb.stories.tsx
+++ b/src/components/basic/Breadcrumb/Breadcrumb.stories.tsx
@@ -19,7 +19,7 @@
  ********************************************************************************/
 
 import { Link, Typography } from '@mui/material'
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { Breadcrumb as Component } from '.'
 
@@ -58,7 +58,7 @@ const breadcrumbs = [
   </Typography>,
 ]
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/Button/BackButton.stories.tsx
+++ b/src/components/basic/Button/BackButton.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import type { ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { BackButton as Component } from './BackButton'
 
@@ -33,7 +33,7 @@ export default {
   },
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/Button/BackButton.stories.tsx
+++ b/src/components/basic/Button/BackButton.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type StoryFn } from '@storybook/react'
-
 import { BackButton as Component } from './BackButton'
 
 export default {

--- a/src/components/basic/Button/LoadMoreButton.stories.tsx
+++ b/src/components/basic/Button/LoadMoreButton.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { LoadMoreButton as Component } from './LoadMoreButton'
 
@@ -29,7 +29,7 @@ export default {
   argTypes: {},
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/Button/LoadMoreButton.stories.tsx
+++ b/src/components/basic/Button/LoadMoreButton.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type StoryFn } from '@storybook/react'
-
 import { LoadMoreButton as Component } from './LoadMoreButton'
 
 export default {

--- a/src/components/basic/Button/ScrollToTopButton.stories.tsx
+++ b/src/components/basic/Button/ScrollToTopButton.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { ScrollToTopButton as Component } from './ScrollToTopButton'
 
@@ -33,7 +33,7 @@ export default {
   },
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/Carousel/Carousel.stories.tsx
+++ b/src/components/basic/Carousel/Carousel.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 import { Carousel as Component } from '.'
 import { theme } from '../../../theme'
 import uniqueId from 'lodash/uniqueId'
@@ -40,7 +40,7 @@ const itemsArray = [
   'Element 5',
 ]
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => (
   <Component {...args}>

--- a/src/components/basic/Carousel/CarouselBox.stories.tsx
+++ b/src/components/basic/Carousel/CarouselBox.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 import { CarouselBox as Component } from './CarouselBox'
 import { theme } from '../../../theme'
 import uniqueId from 'lodash/uniqueId'
@@ -40,7 +40,7 @@ const itemsArray = [
   'Element 5',
 ]
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => (
   <Component {...args}>

--- a/src/components/basic/CategoryDivider/CategoryDivider.stories.tsx
+++ b/src/components/basic/CategoryDivider/CategoryDivider.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { CategoryDivider as Component } from '.'
 
@@ -29,7 +29,7 @@ export default {
   argTypes: {},
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/Checkbox/Checkbox.stories.tsx
+++ b/src/components/basic/Checkbox/Checkbox.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { Checkbox as Component } from '.'
 
@@ -33,7 +33,7 @@ export default {
   },
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/Chip/DraggableChip.stories.tsx
+++ b/src/components/basic/Chip/DraggableChip.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { DraggableChip as Component } from './DraggableChip'
 
@@ -33,7 +33,7 @@ export default {
   },
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args}>{args.children}</Component>
 

--- a/src/components/basic/Chip/chip.stories.tsx
+++ b/src/components/basic/Chip/chip.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 import { Chip as Component } from '.'
 
 export default {
@@ -29,7 +29,7 @@ export default {
   parameters: {},
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/CircularProgress/circularProgress.stories.tsx
+++ b/src/components/basic/CircularProgress/circularProgress.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { CircularProgress as Component } from '.'
 
@@ -28,7 +28,7 @@ export default {
   tags: ['autodocs'],
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/CustomAccordion/CustomAccordion.stories.tsx
+++ b/src/components/basic/CustomAccordion/CustomAccordion.stories.tsx
@@ -19,7 +19,7 @@
  ********************************************************************************/
 
 import { Box, Divider, Typography } from '@mui/material'
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 import { CustomAccordion as Component } from '.'
 import { Table } from '../StaticTable/StaticTable.stories'
 import { type CustomAccordionProps } from './Item'
@@ -35,7 +35,7 @@ export default {
   },
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/Datepicker/Datepicker.stories.tsx
+++ b/src/components/basic/Datepicker/Datepicker.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 import { Box } from '@mui/material'
 
 import { Datepicker as Component, type DateType } from '.'
@@ -30,7 +30,7 @@ export default {
   argTypes: {},
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => (
   <Box sx={{ width: '320px' }}>

--- a/src/components/basic/Dialog/Dialog.stories.tsx
+++ b/src/components/basic/Dialog/Dialog.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { Dialog as Component } from '.'
 import { Button } from '../Button'
@@ -48,7 +48,7 @@ export default {
   },
 }
 
-const DialogTemplate: ComponentStory<typeof Component> = (
+const DialogTemplate: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => {
   const { title, intro, content, helperText, ...componentArgs } = args

--- a/src/components/basic/Dialog/DialogActions.stories.tsx
+++ b/src/components/basic/Dialog/DialogActions.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { DialogActions as Component } from './DialogActions'
 import { Button } from '../Button'
@@ -29,7 +29,7 @@ export default {
   tags: ['autodocs'],
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => (
   <Component {...args}>

--- a/src/components/basic/Dialog/DialogHeader.stories.tsx
+++ b/src/components/basic/Dialog/DialogHeader.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { DialogHeader as Component } from './DialogHeader'
 
@@ -28,7 +28,7 @@ export default {
   tags: ['autodocs'],
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/DropdownMenu/DropdownMenu.stories.tsx
+++ b/src/components/basic/DropdownMenu/DropdownMenu.stories.tsx
@@ -21,7 +21,7 @@
 import EditIcon from '@mui/icons-material/Edit'
 import FileCopyIcon from '@mui/icons-material/FileCopy'
 import MenuItem from '@mui/material/MenuItem'
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { DropdownMenu as Component } from '.'
 
@@ -34,7 +34,7 @@ export default {
   },
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => (
   <Component {...args}>

--- a/src/components/basic/Dropzone/DropArea.stories.tsx
+++ b/src/components/basic/Dropzone/DropArea.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { DropArea as Component } from './components/DropArea'
 
@@ -38,7 +38,7 @@ export default {
   },
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/Dropzone/DropPreview.stories.tsx
+++ b/src/components/basic/Dropzone/DropPreview.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { DropPreview as Component } from './components/DropPreview'
 import { UploadStatus } from './types'
@@ -62,7 +62,7 @@ export default {
   },
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => (
   <Component {...args} uploadFiles={args.placeholder ? [] : args.uploadFiles} />

--- a/src/components/basic/Dropzone/DropPreviewFile.stories.tsx
+++ b/src/components/basic/Dropzone/DropPreviewFile.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { DropPreviewFile as Component } from './components/DropPreviewFile'
 import { UploadStatus } from './types'
@@ -53,7 +53,7 @@ export default {
   },
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => {
   const { name, size, status, progressPercent, ...props } = args

--- a/src/components/basic/ErrorBar/ErrorBar.stories.tsx
+++ b/src/components/basic/ErrorBar/ErrorBar.stories.tsx
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { ErrorBar as Component } from './ErrorBar'
 
@@ -28,7 +28,7 @@ export default {
   argTypes: {},
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/ErrorPage/ErrorPage.stories.tsx
+++ b/src/components/basic/ErrorPage/ErrorPage.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { ErrorPage as Component } from '.'
 
@@ -29,7 +29,7 @@ export default {
   argTypes: {},
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/Expand/Expand.stories.tsx
+++ b/src/components/basic/Expand/Expand.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { Expand as Component } from '.'
 
@@ -33,7 +33,7 @@ export default {
   },
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/Headers/MainHeader/MainHeader.stories.tsx
+++ b/src/components/basic/Headers/MainHeader/MainHeader.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { MainHeader as Component } from './MainHeader'
 
@@ -29,7 +29,7 @@ export default {
   argTypes: {},
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/Headers/PageHeader/PageHeader.stories.tsx
+++ b/src/components/basic/Headers/PageHeader/PageHeader.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { PageHeader as Component } from './PageHeader'
 
@@ -29,7 +29,7 @@ export default {
   argTypes: {},
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/IconButton/IconButton.stories.tsx
+++ b/src/components/basic/IconButton/IconButton.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { IconButton as Component } from '.'
 import AddIcon from '@mui/icons-material/Add'
@@ -35,7 +35,7 @@ export default {
   },
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/ImageGallery/ImageGallery.stories.tsx
+++ b/src/components/basic/ImageGallery/ImageGallery.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { ImageGallery as Component } from '.'
 
@@ -28,7 +28,7 @@ export default {
   tags: ['autodocs'],
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/ImageGallery/ImageGalleryItem.stories.tsx
+++ b/src/components/basic/ImageGallery/ImageGalleryItem.stories.tsx
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 import { ImageItem } from './ImageItem'
 
 export default {
@@ -25,7 +25,7 @@ export default {
   component: ImageItem,
 }
 
-const Template: ComponentStory<typeof ImageItem> = (
+const Template: StoryFn<typeof ImageItem> = (
   args: React.ComponentProps<typeof ImageItem>
 ) => <ImageItem {...args} />
 

--- a/src/components/basic/Input/Input.stories.tsx
+++ b/src/components/basic/Input/Input.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { Input as Component } from '.'
 
@@ -33,7 +33,7 @@ export default {
   },
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/LanguageSwitch/LanguageSwitch.stories.tsx
+++ b/src/components/basic/LanguageSwitch/LanguageSwitch.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { LanguageSwitch as Component } from '.'
 
@@ -33,7 +33,7 @@ export default {
   },
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/LoadingButton/LoadingButton.stories.tsx
+++ b/src/components/basic/LoadingButton/LoadingButton.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { LoadingButton as Component } from '.'
 
@@ -29,7 +29,7 @@ export default {
   argTypes: {},
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/Logo/Logo.stories.tsx
+++ b/src/components/basic/Logo/Logo.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { Logo as Component } from '.'
 
@@ -28,7 +28,7 @@ export default {
   tags: ['autodocs'],
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/MainNavigation/MainNavigation.stories.tsx
+++ b/src/components/basic/MainNavigation/MainNavigation.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 import { Box } from '@mui/material'
 import CXLogoText from '../../../assets/logo/cx-logo-text.svg'
 
@@ -41,7 +41,7 @@ const items = [
   { href: '/partnernetwork', title: 'Partner Network' },
 ]
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => (
   <Component {...args}>

--- a/src/components/basic/Menu/Menu.stories.tsx
+++ b/src/components/basic/Menu/Menu.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { Menu as Component } from '.'
 
@@ -28,7 +28,7 @@ export default {
   tags: ['autodocs'],
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/MultiSelectList/MultiSelectList.stories.tsx
+++ b/src/components/basic/MultiSelectList/MultiSelectList.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { MultiSelectList as Component } from '.'
 
@@ -77,7 +77,7 @@ const items = [
   },
 ]
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/NewSubNavigation/NewSubNavigation.stories.tsx
+++ b/src/components/basic/NewSubNavigation/NewSubNavigation.stories.tsx
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 import { NewSubNavigation as Component } from '.'
 
 export default {
@@ -27,7 +27,7 @@ export default {
   argTypes: {},
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/Notifications/PageNotification/PageNotification.stories.tsx
+++ b/src/components/basic/Notifications/PageNotification/PageNotification.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { PageNotifications as Component } from '.'
 
@@ -28,7 +28,7 @@ export default {
   tags: ['autodocs'],
   argTypes: {},
 }
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args}>{args.children}</Component>
 

--- a/src/components/basic/Notifications/Snackbar/PageSnackbar.stories.tsx
+++ b/src/components/basic/Notifications/Snackbar/PageSnackbar.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { PageSnackbar as Component } from '.'
 
@@ -29,7 +29,7 @@ export default {
   argTypes: {},
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/Notifications/Snackbar/PageSnackbarStack.stories.tsx
+++ b/src/components/basic/Notifications/Snackbar/PageSnackbarStack.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 import { PageSnackbar } from './index'
 
 import { PageSnackbarStack as Component } from './PageSnackbarStack'
@@ -36,7 +36,7 @@ export default {
   },
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => {
   return (

--- a/src/components/basic/OrderStatusButton/OrderStatusButton.stories.tsx
+++ b/src/components/basic/OrderStatusButton/OrderStatusButton.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { OrderStatusButton as Component } from '.'
 
@@ -29,7 +29,7 @@ export default {
   argTypes: {},
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/ProcessList/ProcessList.stories.tsx
+++ b/src/components/basic/ProcessList/ProcessList.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { ProcessList as Component } from '.'
 
@@ -68,7 +68,7 @@ const processListElements = [
   },
 ]
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/Progress/CircleProgress/CircleProgress.stories.tsx
+++ b/src/components/basic/Progress/CircleProgress/CircleProgress.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { CircleProgress as Component } from '.'
 
@@ -29,7 +29,7 @@ export default {
   argTypes: {},
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/Progress/LinearProgress/LinearProgressWithValueLabel.stories.tsx
+++ b/src/components/basic/Progress/LinearProgress/LinearProgressWithValueLabel.stories.tsx
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { LinearProgressWithValueLabel as Component } from './LinearProgressWithValueLabel'
 
@@ -28,7 +28,7 @@ export default {
   argTypes: {},
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/QuickLinks/QuickLinks.stories.tsx
+++ b/src/components/basic/QuickLinks/QuickLinks.stories.tsx
@@ -18,7 +18,7 @@
  ********************************************************************************/
 
 import React from 'react'
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 import { QuickLinks as Component } from './index'
 
 export default {
@@ -28,7 +28,7 @@ export default {
   argTypes: {},
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/Radio/Radio.stories.tsx
+++ b/src/components/basic/Radio/Radio.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { Radio as Component } from '.'
 
@@ -33,7 +33,7 @@ export default {
   },
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/Rating/Rating.stories.tsx
+++ b/src/components/basic/Rating/Rating.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { Rating as Component } from '.'
 
@@ -28,7 +28,7 @@ export default {
   tags: ['autodocs'],
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/SearchInput/SearchInput.stories.tsx
+++ b/src/components/basic/SearchInput/SearchInput.stories.tsx
@@ -19,7 +19,7 @@
  ********************************************************************************/
 
 import { useState } from 'react'
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { SearchInput as Component } from '.'
 
@@ -30,7 +30,7 @@ export default {
   argTypes: {},
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/SelectList/SelectList.stories.tsx
+++ b/src/components/basic/SelectList/SelectList.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { SelectList as Component } from '.'
 
@@ -62,7 +62,7 @@ const countries = [
   },
 ]
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/SideMenu/SideMenu.stories.tsx
+++ b/src/components/basic/SideMenu/SideMenu.stories.tsx
@@ -19,7 +19,7 @@
  ********************************************************************************/
 
 import { Box } from '@mui/material'
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { SideMenu as Component } from '.'
 import { DraggableChip } from '../Chip/DraggableChip'
@@ -37,7 +37,7 @@ export default {
   },
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/SortOption/SortOption.stories.tsx
+++ b/src/components/basic/SortOption/SortOption.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 import { SortOption as Component } from '.'
 
 export default {
@@ -27,7 +27,7 @@ export default {
   tags: ['autodocs'],
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => (
   <div

--- a/src/components/basic/StaticTable/StaticTable.stories.tsx
+++ b/src/components/basic/StaticTable/StaticTable.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { StaticTable as Component } from '.'
 
@@ -28,7 +28,7 @@ export default {
   tags: ['autodocs'],
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/Stepper/RoundedStepper.stories.tsx
+++ b/src/components/basic/Stepper/RoundedStepper.stories.tsx
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { RoundedStepper as Component } from './RoundedStepper'
 
@@ -43,7 +43,7 @@ const stepperElements = [
   },
 ]
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/Stepper/Stepper.stories.tsx
+++ b/src/components/basic/Stepper/Stepper.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { Stepper as Component } from '.'
 
@@ -59,7 +59,7 @@ const stepperElements = [
   },
 ]
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/SubNavigation/SubNavigation.stories.tsx
+++ b/src/components/basic/SubNavigation/SubNavigation.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 import { SubNavigation as Component } from '.'
 
 export default {
@@ -28,7 +28,7 @@ export default {
   argTypes: {},
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/Table/components/StatusTag/statusTag.stories.tsx
+++ b/src/components/basic/Table/components/StatusTag/statusTag.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 import { StatusTag as Component } from '.'
 
 export default {
@@ -28,7 +28,7 @@ export default {
   argTypes: {},
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/Table/table.stories.tsx
+++ b/src/components/basic/Table/table.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { Table as Component } from '.'
 import type {
@@ -66,7 +66,7 @@ export default {
   argTypes: {},
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/Tabs/TabPanel.stories.tsx
+++ b/src/components/basic/Tabs/TabPanel.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 import { TabPanel as Component } from './TabPanel'
 
 export default {
@@ -35,7 +35,7 @@ export default {
   },
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args}>TabPanel Content</Component>
 

--- a/src/components/basic/Tabs/Tabs.stories.tsx
+++ b/src/components/basic/Tabs/Tabs.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import GroupOutlinedIcon from '@mui/icons-material/GroupOutlined'
 import PersonOutlinedIcon from '@mui/icons-material/PersonOutlined'
@@ -41,7 +41,7 @@ export default {
   },
 }
 
-const Template: ComponentStory<typeof ReactComponent> = () => {
+const Template: StoryFn<typeof ReactComponent> = () => {
   const [activeTab, setActiveTab] = React.useState(0)
 
   const handleChange = (_: unknown, newValue: number) => {

--- a/src/components/basic/Textarea/Textarea.stories.tsx
+++ b/src/components/basic/Textarea/Textarea.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { Textarea as Component } from '.'
 
@@ -33,7 +33,7 @@ export default {
   },
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/ToggleSwitch/ToggleSwitch.stories.tsx
+++ b/src/components/basic/ToggleSwitch/ToggleSwitch.stories.tsx
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 import { ToggleSwitch as Component } from '.'
 import { useState } from 'react'
 
@@ -27,7 +27,7 @@ export default {
   tags: ['autodocs'],
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => {
   const [checked, setChecked] = useState(false)

--- a/src/components/basic/ToolTips/ToolTips.stories.tsx
+++ b/src/components/basic/ToolTips/ToolTips.stories.tsx
@@ -19,7 +19,7 @@
  ********************************************************************************/
 
 import { Box } from '@mui/material'
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 import { Tooltips as Component } from '.'
 import { Button } from '../Button'
 
@@ -29,7 +29,7 @@ export default {
   tags: ['autodocs'],
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => (
   <Box

--- a/src/components/basic/UserAvatar/UserAvatar.stories.tsx
+++ b/src/components/basic/UserAvatar/UserAvatar.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { UserAvatar as Component } from '.'
 
@@ -29,7 +29,7 @@ export default {
   argTypes: {},
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/VerticalTabs/VerticalTabs.stories.tsx
+++ b/src/components/basic/VerticalTabs/VerticalTabs.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 import { Box, Typography } from '@mui/material'
 
 import { type TabPanelType, VerticalTabs as Component } from '.'
@@ -84,7 +84,7 @@ const items: TabPanelType[] = [
     description: <Typography variant="h5">User Account</Typography>,
   },
 ]
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/basic/ViewSelector/ViewSelector.stories.tsx
+++ b/src/components/basic/ViewSelector/ViewSelector.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 import { ViewSelector as Component, type View } from '.'
 
 export default {
@@ -28,7 +28,7 @@ export default {
   argTypes: {},
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/content/Cards/AboutCard.stories.tsx
+++ b/src/components/content/Cards/AboutCard.stories.tsx
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { AboutCard as Component } from './AboutCard'
 
@@ -27,7 +27,7 @@ export default {
   tags: ['autodocs'],
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/content/Cards/CardDecision.stories.tsx
+++ b/src/components/content/Cards/CardDecision.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 import { StatusVariants } from './CardChip'
 
 import { CardDecision as Component } from './CardDecision'
@@ -30,7 +30,7 @@ export default {
   argTypes: {},
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/content/Cards/CardHorizontal.stories.tsx
+++ b/src/components/content/Cards/CardHorizontal.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 import { StatusVariants } from './CardChip'
 
 import { CardHorizontal as Component } from './CardHorizontal'
@@ -30,7 +30,7 @@ export default {
   argTypes: {},
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/content/Cards/ContentCard.stories.tsx
+++ b/src/components/content/Cards/ContentCard.stories.tsx
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { ContentCard as Component } from './ContentCard'
 
@@ -28,7 +28,7 @@ export default {
   argTypes: {},
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/content/Cards/MarketplaceCard.stories.tsx
+++ b/src/components/content/Cards/MarketplaceCard.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { Cards as Component } from '.'
 
@@ -29,7 +29,7 @@ export default {
   argTypes: {},
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/content/Navigation/Navigation.stories.tsx
+++ b/src/components/content/Navigation/Navigation.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { Navigation as Component } from '.'
 
@@ -29,7 +29,7 @@ export default {
   argTypes: {},
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 

--- a/src/components/content/UserMenu/UserMenu.stories.tsx
+++ b/src/components/content/UserMenu/UserMenu.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { UserMenu as Component } from '.'
 import { LanguageSwitch } from '../../basic/LanguageSwitch'
@@ -30,7 +30,7 @@ export default {
   tags: ['autodocs'],
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => (
   <Component {...args}>

--- a/src/components/content/UserNav/UserNav.stories.tsx
+++ b/src/components/content/UserNav/UserNav.stories.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import { type StoryFn } from '@storybook/react'
 
 import { UserNav as Component } from '.'
 
@@ -28,7 +28,7 @@ export default {
   tags: ['autodocs'],
 }
 
-const Template: ComponentStory<typeof Component> = (
+const Template: StoryFn<typeof Component> = (
   args: React.ComponentProps<typeof Component>
 ) => <Component {...args} />
 


### PR DESCRIPTION
## Description

Code Cleanup: Updated deprecated type usage

## Why

After migrating to v8, there are still instances of a deprecated type that has been removed. A replacement type is available.

## Issue

#305 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally