### PR TITLE
refactor: structure for import order

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,6 +28,24 @@
         "linebreak-style": ["error", "unix"],
         "quotes": ["error", "single"],
         "semi": ["error", "never"],
+        "import/order": [
+          "error",
+          {
+            "groups": [
+              "builtin",
+              "external",
+              "internal",
+              "parent",
+              "sibling",
+              "index"
+            ],
+            "alphabetize": {
+              "order": "asc",
+              "caseInsensitive": true
+            },
+            "newlines-between": "never"
+          }
+        ],
         "comma-dangle": 0,
         "react/react-in-jsx-scope": 0,
         "@typescript-eslint/comma-dangle": 0,

--- a/src/components/basic/Alert/Alert.stories.tsx
+++ b/src/components/basic/Alert/Alert.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { Alert as Component } from '.'
 
 export default {

--- a/src/components/basic/BaseImage/BaseImage.stories.tsx
+++ b/src/components/basic/BaseImage/BaseImage.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { BaseImage as Component } from '.'
 
 export default {

--- a/src/components/basic/BaseImage/index.tsx
+++ b/src/components/basic/BaseImage/index.tsx
@@ -18,8 +18,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { Box } from '@mui/material'
 import { Buffer } from 'buffer'
+import { Box } from '@mui/material'
 
 interface BaseImageProps {
   image: string

--- a/src/components/basic/Breadcrumb/Breadcrumb.stories.tsx
+++ b/src/components/basic/Breadcrumb/Breadcrumb.stories.tsx
@@ -20,7 +20,6 @@
 
 import { Link, Typography } from '@mui/material'
 import { type ComponentStory } from '@storybook/react'
-
 import { Breadcrumb as Component } from '.'
 
 export default {

--- a/src/components/basic/Button/BackButton.stories.tsx
+++ b/src/components/basic/Button/BackButton.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import type { ComponentStory } from '@storybook/react'
-
 import { BackButton as Component } from './BackButton'
 
 export default {

--- a/src/components/basic/Button/BackButton.tsx
+++ b/src/components/basic/Button/BackButton.tsx
@@ -18,8 +18,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { Button } from '.'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
+import { Button } from '.'
 
 export interface BackButtonProps {
   backButtonLabel?: string

--- a/src/components/basic/Button/Button.stories.tsx
+++ b/src/components/basic/Button/Button.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import type { Meta, StoryObj } from '@storybook/react'
-
 import { Button } from '.'
 
 const meta: Meta<typeof Button> = {

--- a/src/components/basic/Button/LoadMoreButton.stories.tsx
+++ b/src/components/basic/Button/LoadMoreButton.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { LoadMoreButton as Component } from './LoadMoreButton'
 
 export default {

--- a/src/components/basic/Button/LoadMoreButton.tsx
+++ b/src/components/basic/Button/LoadMoreButton.tsx
@@ -18,9 +18,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline'
 import { type ButtonProps as MuiButtonProps } from '@mui/material/Button/Button'
 import { Button } from '.'
-import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline'
 
 export interface LoadMoreButtonProps
   extends Omit<MuiButtonProps, 'color' | 'variant' | 'size'> {

--- a/src/components/basic/Button/ScrollToTopButton.stories.tsx
+++ b/src/components/basic/Button/ScrollToTopButton.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { ScrollToTopButton as Component } from './ScrollToTopButton'
 
 export default {

--- a/src/components/basic/Button/ScrollToTopButton.tsx
+++ b/src/components/basic/Button/ScrollToTopButton.tsx
@@ -17,9 +17,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { IconButton } from '../IconButton'
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward'
 import { useMediaQuery } from '@mui/material'
+import { IconButton } from '../IconButton'
 
 export interface ScrollToTopButtonProps {
   onButtonClick: React.MouseEventHandler

--- a/src/components/basic/Carousel/Carousel.stories.tsx
+++ b/src/components/basic/Carousel/Carousel.stories.tsx
@@ -19,9 +19,9 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-import { Carousel as Component } from '.'
-import { theme } from '../../../theme'
 import uniqueId from 'lodash/uniqueId'
+import { theme } from '../../../theme'
+import { Carousel as Component } from '.'
 
 export default {
   title: 'Carousel',

--- a/src/components/basic/Carousel/CarouselBox.stories.tsx
+++ b/src/components/basic/Carousel/CarouselBox.stories.tsx
@@ -19,9 +19,9 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-import { CarouselBox as Component } from './CarouselBox'
-import { theme } from '../../../theme'
 import uniqueId from 'lodash/uniqueId'
+import { theme } from '../../../theme'
+import { CarouselBox as Component } from './CarouselBox'
 
 export default {
   title: 'Carousel',

--- a/src/components/basic/Carousel/CarouselBox.tsx
+++ b/src/components/basic/Carousel/CarouselBox.tsx
@@ -18,15 +18,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import React, { useState, Children, useEffect } from 'react'
-import Slider from 'react-slick'
-import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
-import { IconButton } from '../IconButton'
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
 import { Box } from '@mui/material'
 import uniqueId from 'lodash/uniqueId'
-import { Typography } from '../Typography'
+import React, { useState, Children, useEffect } from 'react'
+import Slider from 'react-slick'
 import { theme } from '../../../theme'
+import { IconButton } from '../IconButton'
+import { Typography } from '../Typography'
 import 'slick-carousel/slick/slick.css'
 import 'slick-carousel/slick/slick-theme.css'
 

--- a/src/components/basic/Carousel/index.tsx
+++ b/src/components/basic/Carousel/index.tsx
@@ -18,14 +18,14 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+import ArrowBackIcon from '@mui/icons-material/ArrowBack'
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
+import { Box } from '@mui/material'
+import uniqueId from 'lodash/uniqueId'
 import { useState, Children, useEffect, useCallback } from 'react'
 import Slider from 'react-slick'
-import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
-import ArrowBackIcon from '@mui/icons-material/ArrowBack'
-import { IconButton } from '../IconButton'
-import { Box } from '@mui/material'
 import { theme } from '../../../theme'
-import uniqueId from 'lodash/uniqueId'
+import { IconButton } from '../IconButton'
 import 'slick-carousel/slick/slick.css'
 import 'slick-carousel/slick/slick-theme.css'
 import { type CarouselNavArrows } from './CarouselBox'

--- a/src/components/basic/CategoryDivider/CategoryDivider.stories.tsx
+++ b/src/components/basic/CategoryDivider/CategoryDivider.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { CategoryDivider as Component } from '.'
 
 export default {

--- a/src/components/basic/Checkbox/Checkbox.stories.tsx
+++ b/src/components/basic/Checkbox/Checkbox.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { Checkbox as Component } from '.'
 
 export default {

--- a/src/components/basic/Chip/DraggableChip.stories.tsx
+++ b/src/components/basic/Chip/DraggableChip.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { DraggableChip as Component } from './DraggableChip'
 
 export default {

--- a/src/components/basic/Chip/DraggableChip.tsx
+++ b/src/components/basic/Chip/DraggableChip.tsx
@@ -18,8 +18,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { Box, type BoxProps, useTheme } from '@mui/material'
 import OpenWithIcon from '@mui/icons-material/OpenWith'
+import { Box, type BoxProps, useTheme } from '@mui/material'
 
 interface DraggableChipProps extends BoxProps {
   isSelected?: boolean

--- a/src/components/basic/Chip/TransitionChip.tsx
+++ b/src/components/basic/Chip/TransitionChip.tsx
@@ -18,9 +18,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import MuiChip, { type ChipProps } from '@mui/material/Chip'
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline'
 import HighlightOffIcon from '@mui/icons-material/HighlightOff'
+import MuiChip, { type ChipProps } from '@mui/material/Chip'
 import { useState } from 'react'
 import { theme } from '../../../theme'
 

--- a/src/components/basic/Chip/index.tsx
+++ b/src/components/basic/Chip/index.tsx
@@ -18,12 +18,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import MuiChip, { type ChipProps } from '@mui/material/Chip'
+import AutorenewIcon from '@mui/icons-material/Autorenew'
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline'
 import HighlightOffIcon from '@mui/icons-material/HighlightOff'
-import { theme } from '../../../theme'
-import AutorenewIcon from '@mui/icons-material/Autorenew'
+import MuiChip, { type ChipProps } from '@mui/material/Chip'
 import React from 'react'
+import { theme } from '../../../theme'
 
 interface ChipCustomProps extends ChipProps {
   type?: 'decline' | 'confirm' | 'plain' | 'delete' | 'progress'

--- a/src/components/basic/CircularProgress/circularProgress.stories.tsx
+++ b/src/components/basic/CircularProgress/circularProgress.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { CircularProgress as Component } from '.'
 
 export default {

--- a/src/components/basic/CustomAccordion/CustomAccordion.stories.tsx
+++ b/src/components/basic/CustomAccordion/CustomAccordion.stories.tsx
@@ -18,13 +18,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { Box, Divider, Typography } from '@mui/material'
-import { type ComponentStory } from '@storybook/react'
-import { CustomAccordion as Component } from '.'
-import { Table } from '../StaticTable/StaticTable.stories'
-import { type CustomAccordionProps } from './Item'
 import HomeOutlinedIcon from '@mui/icons-material/HomeOutlined'
 import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined'
+import { Box, Divider, Typography } from '@mui/material'
+import { type ComponentStory } from '@storybook/react'
+import { Table } from '../StaticTable/StaticTable.stories'
+import { type CustomAccordionProps } from './Item'
+import { CustomAccordion as Component } from '.'
 
 export default {
   title: 'CustomAccordion',

--- a/src/components/basic/CustomAccordion/Item.tsx
+++ b/src/components/basic/CustomAccordion/Item.tsx
@@ -18,12 +18,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import React from 'react'
-import Accordion, { type AccordionProps } from '@mui/material/Accordion'
-import AccordionSummary from '@mui/material/AccordionSummary'
-import AccordionDetails from '@mui/material/AccordionDetails'
-import { AccordionActions, Box, Button, Typography } from '@mui/material'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import { AccordionActions, Box, Button, Typography } from '@mui/material'
+import Accordion, { type AccordionProps } from '@mui/material/Accordion'
+import AccordionDetails from '@mui/material/AccordionDetails'
+import AccordionSummary from '@mui/material/AccordionSummary'
+import React from 'react'
 
 export interface CustomAccordionProps extends AccordionProps {
   expanded: boolean | undefined

--- a/src/components/basic/Datepicker/Datepicker.stories.tsx
+++ b/src/components/basic/Datepicker/Datepicker.stories.tsx
@@ -18,9 +18,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
 import { Box } from '@mui/material'
-
+import { type ComponentStory } from '@storybook/react'
 import { Datepicker as Component, type DateType } from '.'
 
 export default {

--- a/src/components/basic/Datepicker/index.tsx
+++ b/src/components/basic/Datepicker/index.tsx
@@ -18,16 +18,16 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { useEffect, useState } from 'react'
 import { Box, Button } from '@mui/material'
 import { type TextFieldProps } from '@mui/material/TextField'
+import { type PickersDayProps } from '@mui/x-date-pickers'
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFnsV3'
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
 import { DatePicker } from '@mui/x-date-pickers/DatePicker'
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
 import { de } from 'date-fns/locale/de'
 import { enUS } from 'date-fns/locale/en-US'
 import uniqueId from 'lodash/uniqueId'
-import { type PickersDayProps } from '@mui/x-date-pickers'
+import { useEffect, useState } from 'react'
 
 export type DateType = Date | null
 export interface DatepickerProps extends Omit<TextFieldProps, 'variant'> {

--- a/src/components/basic/Dialog/Dialog.stories.tsx
+++ b/src/components/basic/Dialog/Dialog.stories.tsx
@@ -19,12 +19,11 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
-import { Dialog as Component } from '.'
 import { Button } from '../Button'
 import { DialogActions } from './DialogActions'
 import { DialogContent } from './DialogContent'
 import { DialogHeader } from './DialogHeader'
+import { Dialog as Component } from '.'
 
 export default {
   title: 'Modal',

--- a/src/components/basic/Dialog/DialogActions.stories.tsx
+++ b/src/components/basic/Dialog/DialogActions.stories.tsx
@@ -19,9 +19,8 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
-import { DialogActions as Component } from './DialogActions'
 import { Button } from '../Button'
+import { DialogActions as Component } from './DialogActions'
 
 export default {
   title: 'Modal',

--- a/src/components/basic/Dialog/DialogHeader.stories.tsx
+++ b/src/components/basic/Dialog/DialogHeader.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { DialogHeader as Component } from './DialogHeader'
 
 export default {

--- a/src/components/basic/Dialog/DialogHeader.tsx
+++ b/src/components/basic/Dialog/DialogHeader.tsx
@@ -18,13 +18,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import React from 'react'
+import CheckCircleOutlineOutlinedIcon from '@mui/icons-material/CheckCircleOutlineOutlined'
+import CloseIcon from '@mui/icons-material/Close'
 import { Box, useTheme } from '@mui/material'
 import MuiDialogTitle from '@mui/material/DialogTitle'
-import { Typography } from '../Typography'
+import React from 'react'
 import { IconButton } from '../IconButton'
-import CloseIcon from '@mui/icons-material/Close'
-import CheckCircleOutlineOutlinedIcon from '@mui/icons-material/CheckCircleOutlineOutlined'
+import { Typography } from '../Typography'
 import { CONTENT_SPACING_RIGHT_LEFT } from './index'
 
 export interface DialogHeaderProps {

--- a/src/components/basic/DropdownMenu/DropdownMenu.stories.tsx
+++ b/src/components/basic/DropdownMenu/DropdownMenu.stories.tsx
@@ -22,7 +22,6 @@ import EditIcon from '@mui/icons-material/Edit'
 import FileCopyIcon from '@mui/icons-material/FileCopy'
 import MenuItem from '@mui/material/MenuItem'
 import { type ComponentStory } from '@storybook/react'
-
 import { DropdownMenu as Component } from '.'
 
 export default {

--- a/src/components/basic/Dropzone/DropArea.stories.tsx
+++ b/src/components/basic/Dropzone/DropArea.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { DropArea as Component } from './components/DropArea'
 
 export default {

--- a/src/components/basic/Dropzone/DropPreview.stories.tsx
+++ b/src/components/basic/Dropzone/DropPreview.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { DropPreview as Component } from './components/DropPreview'
 import { UploadStatus } from './types'
 

--- a/src/components/basic/Dropzone/DropPreviewFile.stories.tsx
+++ b/src/components/basic/Dropzone/DropPreviewFile.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { DropPreviewFile as Component } from './components/DropPreviewFile'
 import { UploadStatus } from './types'
 

--- a/src/components/basic/Dropzone/components/DropArea.tsx
+++ b/src/components/basic/Dropzone/components/DropArea.tsx
@@ -18,13 +18,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+import UploadFileIcon from '@mui/icons-material/UploadFile'
 import { Box, Link, useTheme } from '@mui/material'
 import { Fragment, type FunctionComponent, useState } from 'react'
+import { Alert } from '../../Alert'
 import { FileErrorIcon } from '../../CustomIcons/FileErrorIcon'
 import { Typography } from '../../Typography'
-import UploadFileIcon from '@mui/icons-material/UploadFile'
 import { type DropZoneDropAreaTranslations } from '../types'
-import { Alert } from '../../Alert'
 
 export interface DropAreaProps {
   translations: DropZoneDropAreaTranslations

--- a/src/components/basic/Dropzone/components/DropPreviewFile.tsx
+++ b/src/components/basic/Dropzone/components/DropPreviewFile.tsx
@@ -18,15 +18,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 import { Box, IconButton, useTheme } from '@mui/material'
 import { type FunctionComponent, useEffect, useRef, useState } from 'react'
+import { FileIcon } from '../../CustomIcons/FileIcon'
 import {
   type DropZonePreviewTranslations,
   type UploadFile,
   UploadStatus,
 } from '../types'
-import { FileIcon } from '../../CustomIcons/FileIcon'
-import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 
 const FAKE_UPLOAD_DURATION = 6000
 

--- a/src/components/basic/ErrorBar/ErrorBar.stories.tsx
+++ b/src/components/basic/ErrorBar/ErrorBar.stories.tsx
@@ -18,7 +18,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { ErrorBar as Component } from './ErrorBar'
 
 export default {

--- a/src/components/basic/ErrorBar/ErrorBar.tsx
+++ b/src/components/basic/ErrorBar/ErrorBar.tsx
@@ -17,11 +17,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import Typography from '@mui/material/Typography'
-import Box from '@mui/material/Box'
-import { Button } from '../Button'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
 import ReportProblemIcon from '@mui/icons-material/ReportProblem'
+import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
+import { Button } from '../Button'
 import './ErrorBar.scss'
 
 export const ErrorBar = ({

--- a/src/components/basic/ErrorPage/ErrorPage.stories.tsx
+++ b/src/components/basic/ErrorPage/ErrorPage.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { ErrorPage as Component } from '.'
 
 export default {

--- a/src/components/basic/ErrorPage/index.tsx
+++ b/src/components/basic/ErrorPage/index.tsx
@@ -19,8 +19,8 @@
  ********************************************************************************/
 
 import { Box } from '@mui/material'
-import { ErrorDescription } from './components/ErrorDescription'
 import { ErrorActions } from './components/ErrorActions'
+import { ErrorDescription } from './components/ErrorDescription'
 import { ErrorImage } from './components/ErrorImage'
 
 export interface ErrorPageProps {

--- a/src/components/basic/Expand/Expand.stories.tsx
+++ b/src/components/basic/Expand/Expand.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { Expand as Component } from '.'
 
 export default {

--- a/src/components/basic/Expand/index.tsx
+++ b/src/components/basic/Expand/index.tsx
@@ -18,10 +18,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { useState } from 'react'
-import { Collapse } from '@mui/material'
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown'
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp'
+import { Collapse } from '@mui/material'
+import { useState } from 'react'
 import { Typography } from '../Typography'
 
 export const Expand = ({

--- a/src/components/basic/Headers/MainHeader/Components/MainHeaderTitle.tsx
+++ b/src/components/basic/Headers/MainHeader/Components/MainHeaderTitle.tsx
@@ -18,8 +18,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type MainHeaderProps } from '../MainHeader'
 import { Typography } from '../../../Typography'
+import { type MainHeaderProps } from '../MainHeader'
 
 export const MainHeaderTitle = ({
   title,

--- a/src/components/basic/Headers/MainHeader/MainHeader.stories.tsx
+++ b/src/components/basic/Headers/MainHeader/MainHeader.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { MainHeader as Component } from './MainHeader'
 
 export default {

--- a/src/components/basic/Headers/PageHeader/PageHeader.stories.tsx
+++ b/src/components/basic/Headers/PageHeader/PageHeader.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { PageHeader as Component } from './PageHeader'
 
 export default {

--- a/src/components/basic/Headers/PageHeader/PageHeader.tsx
+++ b/src/components/basic/Headers/PageHeader/PageHeader.tsx
@@ -19,11 +19,11 @@
  ********************************************************************************/
 
 import { Box, useTheme } from '@mui/material'
-import { HeaderTitle } from './Components/HeaderTitle'
+import { mainNavigationHeight } from '../../MainNavigation'
 import { HeaderSubtractOption1 } from './Components/HeaderSubtractOption1'
 import { HeaderSubtractOption2 } from './Components/HeaderSubtractOption2'
 import { HeaderSubtractOption3 } from './Components/HeaderSubtractOption3'
-import { mainNavigationHeight } from '../../MainNavigation'
+import { HeaderTitle } from './Components/HeaderTitle'
 
 export interface PageHeaderProps {
   children?: React.ReactNode

--- a/src/components/basic/Hyperlink/Hyperlink.stories.tsx
+++ b/src/components/basic/Hyperlink/Hyperlink.stories.tsx
@@ -17,9 +17,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+import { Info } from '@mui/icons-material'
 import type { Meta, StoryObj } from '@storybook/react'
 import { Hyperlink } from '.'
-import { Info } from '@mui/icons-material'
 
 const meta: Meta<typeof Hyperlink> = {
   title: 'Hyperlink',

--- a/src/components/basic/Icon/Icon.stories.tsx
+++ b/src/components/basic/Icon/Icon.stories.tsx
@@ -17,14 +17,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type Meta, type StoryFn } from '@storybook/react'
-
-import { Icon as Component, type IconProps } from '.'
 import { Box } from '@mui/material'
-import { IconButton } from '../IconButton'
-import { Typography } from '../Typography'
+import { type Meta, type StoryFn } from '@storybook/react'
 import { type ReactNode } from 'react'
 import { Button } from '../Button'
+import { IconButton } from '../IconButton'
+import { Typography } from '../Typography'
+import { Icon as Component, type IconProps } from '.'
 const meta: Meta<typeof Component> = {
   title: 'Icon',
   component: Component,

--- a/src/components/basic/Icon/index.tsx
+++ b/src/components/basic/Icon/index.tsx
@@ -17,9 +17,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import React from 'react'
 import * as MUIIcons from '@mui/icons-material'
 import { type SvgIconProps } from '@mui/material/SvgIcon'
+import React from 'react'
 
 // Extend the Mui SvgIcon size props
 declare module '@mui/material/SvgIcon' {

--- a/src/components/basic/IconButton/IconButton.stories.tsx
+++ b/src/components/basic/IconButton/IconButton.stories.tsx
@@ -18,11 +18,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
-
-import { IconButton as Component } from '.'
 import AddIcon from '@mui/icons-material/Add'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
+import { type ComponentStory } from '@storybook/react'
+import { IconButton as Component } from '.'
 
 export default {
   title: 'Buttons',

--- a/src/components/basic/Image/Image.stories.tsx
+++ b/src/components/basic/Image/Image.stories.tsx
@@ -18,8 +18,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { Image as Component } from '.'
 import type { Meta, StoryObj } from '@storybook/react'
+import { Image as Component } from '.'
 
 const meta: Meta<typeof Component> = {
   component: Component,

--- a/src/components/basic/ImageGallery/ImageGallery.stories.tsx
+++ b/src/components/basic/ImageGallery/ImageGallery.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { ImageGallery as Component } from '.'
 
 export default {

--- a/src/components/basic/ImageGallery/ImageItemOverlay.tsx
+++ b/src/components/basic/ImageGallery/ImageItemOverlay.tsx
@@ -18,14 +18,14 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import MuiDialog from '@mui/material/Dialog'
-import { type ImageType } from './types'
-import { IconButton } from '../IconButton'
 import CloseIcon from '@mui/icons-material/Close'
 import { useTheme } from '@mui/material'
+import MuiDialog from '@mui/material/Dialog'
 import MuiDialogContent from '@mui/material/DialogContent'
-import { Typography } from '../Typography'
+import { IconButton } from '../IconButton'
 import { Image } from '../Image'
+import { Typography } from '../Typography'
+import { type ImageType } from './types'
 
 interface ImageItemOverlayProps {
   onClose: () => void

--- a/src/components/basic/ImageGallery/index.tsx
+++ b/src/components/basic/ImageGallery/index.tsx
@@ -18,12 +18,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+import { useMediaQuery } from '@mui/material'
 import { useState } from 'react'
 import { Carousel } from '../Carousel'
-import { type ImageType } from './types'
-import ImageItemOverlay from './ImageItemOverlay'
 import { Image } from '../Image'
-import { useMediaQuery } from '@mui/material'
+import ImageItemOverlay from './ImageItemOverlay'
+import { type ImageType } from './types'
 
 export const ImageGallery = ({
   gallery,

--- a/src/components/basic/Input/Input.stories.tsx
+++ b/src/components/basic/Input/Input.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { Input as Component } from '.'
 
 export default {

--- a/src/components/basic/Input/index.tsx
+++ b/src/components/basic/Input/index.tsx
@@ -18,6 +18,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+import ErrorOutline from '@mui/icons-material/ErrorOutline'
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline'
 import {
   TextField,
   type TextFieldProps,
@@ -27,8 +29,6 @@ import {
   Box,
   FormControl,
 } from '@mui/material'
-import ErrorOutline from '@mui/icons-material/ErrorOutline'
-import HelpOutlineIcon from '@mui/icons-material/HelpOutline'
 import { Tooltips } from '../ToolTips'
 
 interface InputProps extends Omit<TextFieldProps, 'variant'> {

--- a/src/components/basic/LanguageSwitch/LanguageSwitch.stories.tsx
+++ b/src/components/basic/LanguageSwitch/LanguageSwitch.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { LanguageSwitch as Component } from '.'
 
 export default {

--- a/src/components/basic/LoadingButton/LoadingButton.stories.tsx
+++ b/src/components/basic/LoadingButton/LoadingButton.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { LoadingButton as Component } from '.'
 
 export default {

--- a/src/components/basic/Logo/Logo.stories.tsx
+++ b/src/components/basic/Logo/Logo.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { Logo as Component } from '.'
 
 export default {

--- a/src/components/basic/Logo/index.tsx
+++ b/src/components/basic/Logo/index.tsx
@@ -18,9 +18,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import CXLogo from '../../../assets/logo/cx-logo.svg'
 import CXLogoShort from '../../../assets/logo/cx-logo-short.svg'
 import CXLogoText from '../../../assets/logo/cx-logo-text.svg'
+import CXLogo from '../../../assets/logo/cx-logo.svg'
 import { Image, LogoGrayData } from '../Image'
 
 interface LogoProps {

--- a/src/components/basic/MainNavigation/MainNavigation.stories.tsx
+++ b/src/components/basic/MainNavigation/MainNavigation.stories.tsx
@@ -18,14 +18,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
+import PersonOutlineIcon from '@mui/icons-material/PersonOutline'
 import { Box } from '@mui/material'
+import { type ComponentStory } from '@storybook/react'
 import CXLogoText from '../../../assets/logo/cx-logo-text.svg'
-
-import { MainNavigation as Component } from '.'
 import { Button } from '../Button'
 import { IconButton } from '../IconButton'
-import PersonOutlineIcon from '@mui/icons-material/PersonOutline'
+import { MainNavigation as Component } from '.'
 
 export default {
   title: 'Navigation',

--- a/src/components/basic/MainNavigation/index.tsx
+++ b/src/components/basic/MainNavigation/index.tsx
@@ -18,10 +18,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { Children } from 'react'
 import { Box } from '@mui/material'
-import { type MenuProps } from '../Menu'
+import { Children } from 'react'
 import { Navigation } from '../../content/Navigation'
+import { type MenuProps } from '../Menu'
 
 export interface MainNavigationProps extends MenuProps {
   children?: React.ReactNode

--- a/src/components/basic/Menu/Menu.stories.tsx
+++ b/src/components/basic/Menu/Menu.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { Menu as Component } from '.'
 
 export default {

--- a/src/components/basic/Menu/MenuItem.tsx
+++ b/src/components/basic/Menu/MenuItem.tsx
@@ -28,8 +28,8 @@ import {
   useTheme,
 } from '@mui/material'
 import { useState } from 'react'
-import { type MenuType, type NotificationBadgeType } from '.'
 import { Typography } from '../Typography'
+import { type MenuType, type NotificationBadgeType } from '.'
 
 type LinkItem = Partial<Record<'href' | 'to', string>>
 

--- a/src/components/basic/MultiSelectList/Components/SelectAddMore.tsx
+++ b/src/components/basic/MultiSelectList/Components/SelectAddMore.tsx
@@ -20,10 +20,10 @@
 
 import { Box } from '@mui/material'
 import uniqueId from 'lodash/uniqueId'
+import { type TagSizeType } from '..'
 import { Button } from '../../Button'
 import { Typography } from '../../Typography'
 import { SelectedTag } from './SelectedTag'
-import { type TagSizeType } from '..'
 
 interface SelectAddMoreProps {
   selected: Array<Record<string, string>>

--- a/src/components/basic/MultiSelectList/Components/SelectedTag.tsx
+++ b/src/components/basic/MultiSelectList/Components/SelectedTag.tsx
@@ -19,9 +19,9 @@
  ********************************************************************************/
 
 import { Box, useTheme } from '@mui/material'
-import { Typography } from '../../Typography'
-import { type TagSizeType } from '..'
 import { useEffect, useState } from 'react'
+import { type TagSizeType } from '..'
+import { Typography } from '../../Typography'
 
 interface SelectedTagProps {
   title: string

--- a/src/components/basic/MultiSelectList/MultiSelectList.stories.tsx
+++ b/src/components/basic/MultiSelectList/MultiSelectList.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { MultiSelectList as Component } from '.'
 
 export default {

--- a/src/components/basic/MultiSelectList/index.tsx
+++ b/src/components/basic/MultiSelectList/index.tsx
@@ -23,13 +23,13 @@ import Autocomplete, {
   type AutocompleteRenderInputParams,
   createFilterOptions,
 } from '@mui/material/Autocomplete'
-import parse from 'autosuggest-highlight/parse'
 import match from 'autosuggest-highlight/match'
-import { SelectInput } from './Components/SelectInput'
-import { SelectOptions } from './Components/SelectOptions'
-import { SelectAddMore } from './Components/SelectAddMore'
+import parse from 'autosuggest-highlight/parse'
 import uniqueId from 'lodash/uniqueId'
 import { useEffect, useState } from 'react'
+import { SelectAddMore } from './Components/SelectAddMore'
+import { SelectInput } from './Components/SelectInput'
+import { SelectOptions } from './Components/SelectOptions'
 
 export type TagSizeType = 'small' | 'medium' | 'large'
 export interface PartsType {

--- a/src/components/basic/NewSubNavigation/index.tsx
+++ b/src/components/basic/NewSubNavigation/index.tsx
@@ -17,11 +17,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { Button } from '../Button'
 import EastIcon from '@mui/icons-material/East'
 import MoreVertIcon from '@mui/icons-material/MoreVert'
 import { Box, Divider } from '@mui/material'
 import { useState } from 'react'
+import { Button } from '../Button'
 import { Typography } from '../Typography'
 import './styles.scss'
 

--- a/src/components/basic/Notifications/PageNotification/PageNotification.stories.tsx
+++ b/src/components/basic/Notifications/PageNotification/PageNotification.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { PageNotifications as Component } from '.'
 
 export default {

--- a/src/components/basic/Notifications/PageNotification/index.tsx
+++ b/src/components/basic/Notifications/PageNotification/index.tsx
@@ -18,15 +18,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { Alert, IconButton, Collapse } from '@mui/material'
 import {
   CheckCircleOutline,
   WarningAmber,
   InfoOutlined,
   Close,
 } from '@mui/icons-material'
-import { NotificationContent } from './NotificationContent'
+import { Alert, IconButton, Collapse } from '@mui/material'
 import { theme } from '../../../../theme'
+import { NotificationContent } from './NotificationContent'
 
 export interface PageNotificationsProps {
   severity?: 'error' | 'warning' | 'info' | 'success'

--- a/src/components/basic/Notifications/Snackbar/PageSnackbar.stories.tsx
+++ b/src/components/basic/Notifications/Snackbar/PageSnackbar.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { PageSnackbar as Component } from '.'
 
 export default {

--- a/src/components/basic/Notifications/Snackbar/PageSnackbarStack.stories.tsx
+++ b/src/components/basic/Notifications/Snackbar/PageSnackbarStack.stories.tsx
@@ -19,9 +19,8 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-import { PageSnackbar } from './index'
-
 import { PageSnackbarStack as Component } from './PageSnackbarStack'
+import { PageSnackbar } from './index'
 
 export default {
   title: 'Notifications',

--- a/src/components/basic/Notifications/Snackbar/index.tsx
+++ b/src/components/basic/Notifications/Snackbar/index.tsx
@@ -18,13 +18,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { Box, IconButton, Slide } from '@mui/material'
 import { Close } from '@mui/icons-material'
-import { type SlideProps } from '@mui/material/Slide/Slide'
-import { useCallback, useEffect, useRef, useState } from 'react'
-import Snackbar from '@mui/material/Snackbar'
 import CheckIcon from '@mui/icons-material/Check'
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline'
+import { Box, IconButton, Slide } from '@mui/material'
+import { type SlideProps } from '@mui/material/Slide/Slide'
+import Snackbar from '@mui/material/Snackbar'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 const AUTO_CLOSE_DELAY_MS = 3000
 

--- a/src/components/basic/OrderStatusButton/OrderStatusButton.stories.tsx
+++ b/src/components/basic/OrderStatusButton/OrderStatusButton.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { OrderStatusButton as Component } from '.'
 
 export default {

--- a/src/components/basic/OrderStatusButton/index.tsx
+++ b/src/components/basic/OrderStatusButton/index.tsx
@@ -18,11 +18,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { Box, useTheme } from '@mui/material'
 import CheckCircleOutlinedIcon from '@mui/icons-material/CheckCircleOutlined'
+import { Box, useTheme } from '@mui/material'
+import React from 'react'
 import { Button, type ButtonProps } from '../Button'
 import { Typography } from '../Typography'
-import React from 'react'
 
 interface ButtonInputData {
   isIcon: boolean

--- a/src/components/basic/ProcessList/ListItem.tsx
+++ b/src/components/basic/ProcessList/ListItem.tsx
@@ -19,8 +19,8 @@
  ********************************************************************************/
 
 import { Box } from '@mui/material'
-import { Typography } from '../Typography'
 import { theme } from '../../../theme'
+import { Typography } from '../Typography'
 
 interface ListItemProps {
   step: number

--- a/src/components/basic/ProcessList/ProcessList.stories.tsx
+++ b/src/components/basic/ProcessList/ProcessList.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { ProcessList as Component } from '.'
 
 export default {

--- a/src/components/basic/ProcessList/index.tsx
+++ b/src/components/basic/ProcessList/index.tsx
@@ -19,8 +19,8 @@
  ********************************************************************************/
 
 import { Box } from '@mui/material'
-import { ListItem } from './ListItem'
 import { type StepList } from '../Stepper'
+import { ListItem } from './ListItem'
 
 export interface ProcessListProps {
   list: StepList[]

--- a/src/components/basic/Progress/CircleProgress/CircleProgress.stories.tsx
+++ b/src/components/basic/Progress/CircleProgress/CircleProgress.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { CircleProgress as Component } from '.'
 
 export default {

--- a/src/components/basic/Progress/LinearProgress/LinearProgressWithValueLabel.stories.tsx
+++ b/src/components/basic/Progress/LinearProgress/LinearProgressWithValueLabel.stories.tsx
@@ -18,7 +18,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { LinearProgressWithValueLabel as Component } from './LinearProgressWithValueLabel'
 
 export default {

--- a/src/components/basic/Progress/LinearProgress/LinearProgressWithValueLabel.tsx
+++ b/src/components/basic/Progress/LinearProgress/LinearProgressWithValueLabel.tsx
@@ -17,13 +17,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { useState, useEffect } from 'react'
+import { CircularProgress } from '@mui/material'
+import Box from '@mui/material/Box'
 import LinearProgress, {
   type LinearProgressProps,
 } from '@mui/material/LinearProgress'
 import Typography from '@mui/material/Typography'
-import Box from '@mui/material/Box'
-import { CircularProgress } from '@mui/material'
+import { useState, useEffect } from 'react'
 
 function LinearProgressWithLabel(
   props: LinearProgressProps & { value: number; progressText: string }

--- a/src/components/basic/QuickLinks/QuickLinks.stories.tsx
+++ b/src/components/basic/QuickLinks/QuickLinks.stories.tsx
@@ -17,8 +17,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import React from 'react'
 import { type ComponentStory } from '@storybook/react'
+import React from 'react'
 import { QuickLinks as Component } from './index'
 
 export default {

--- a/src/components/basic/Radio/Radio.stories.tsx
+++ b/src/components/basic/Radio/Radio.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { Radio as Component } from '.'
 
 export default {

--- a/src/components/basic/Radio/index.tsx
+++ b/src/components/basic/Radio/index.tsx
@@ -18,8 +18,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import MuiRadio, { type RadioProps as MuiRadioProps } from '@mui/material/Radio'
 import FormControlLabel from '@mui/material/FormControlLabel'
+import MuiRadio, { type RadioProps as MuiRadioProps } from '@mui/material/Radio'
 
 const ariaLabel = { inputProps: { 'aria-label': 'Radio demo' } }
 

--- a/src/components/basic/Rating/Rating.stories.tsx
+++ b/src/components/basic/Rating/Rating.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { Rating as Component } from '.'
 
 export default {

--- a/src/components/basic/Rating/index.tsx
+++ b/src/components/basic/Rating/index.tsx
@@ -18,9 +18,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import * as React from 'react'
 import Box from '@mui/material/Box'
 import RatingUI from '@mui/material/Rating'
+import * as React from 'react'
 
 interface RatingContentProps {
   defaultRating: number

--- a/src/components/basic/SearchInput/SearchInput.stories.tsx
+++ b/src/components/basic/SearchInput/SearchInput.stories.tsx
@@ -18,9 +18,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { useState } from 'react'
 import { type ComponentStory } from '@storybook/react'
-
+import { useState } from 'react'
 import { SearchInput as Component } from '.'
 
 export default {

--- a/src/components/basic/SearchInput/index.tsx
+++ b/src/components/basic/SearchInput/index.tsx
@@ -18,7 +18,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { useCallback, useEffect, useState } from 'react'
 import SearchIcon from '@mui/icons-material/Search'
 import {
   Box,
@@ -27,6 +26,7 @@ import {
   type TextFieldProps,
   useTheme,
 } from '@mui/material'
+import { useCallback, useEffect, useState } from 'react'
 
 interface SearchProps extends Omit<TextFieldProps, 'variant'> {
   variant?: 'outlined'

--- a/src/components/basic/SelectList/SelectList.stories.tsx
+++ b/src/components/basic/SelectList/SelectList.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { SelectList as Component } from '.'
 
 export default {

--- a/src/components/basic/SelectList/index.tsx
+++ b/src/components/basic/SelectList/index.tsx
@@ -20,13 +20,13 @@
 
 import { type TextFieldProps } from '@mui/material'
 import Autocomplete from '@mui/material/Autocomplete'
-import parse from 'autosuggest-highlight/parse'
 import match from 'autosuggest-highlight/match'
+import parse from 'autosuggest-highlight/parse'
+import isEqual from 'lodash/isEqual'
+import uniqueId from 'lodash/uniqueId'
+import { useEffect, useState } from 'react'
 import { SelectInput } from '../MultiSelectList/Components/SelectInput'
 import { SelectOptions } from '../MultiSelectList/Components/SelectOptions'
-import uniqueId from 'lodash/uniqueId'
-import isEqual from 'lodash/isEqual'
-import { useEffect, useState } from 'react'
 
 interface SelectListProps extends Omit<TextFieldProps, 'variant'> {
   // eslint-disable-next-line

--- a/src/components/basic/SharedThemeProvider/index.tsx
+++ b/src/components/basic/SharedThemeProvider/index.tsx
@@ -19,11 +19,11 @@
  ********************************************************************************/
 
 // Note: The global.scss import must be the first in this file for the library to be build correctly!
-import '../../../scss/global.scss'
 import { ThemeProvider } from '@mui/material/styles'
-import '../../../scss/fonts.scss'
-import { theme } from '../../../theme'
 import type { DefaultTheme } from '@mui/system'
+import { theme } from '../../../theme'
+import '../../../scss/fonts.scss'
+import '../../../scss/global.scss'
 
 interface SharedThemeProviderProps<Theme = DefaultTheme> {
   children: React.ReactNode

--- a/src/components/basic/SideMenu/SideMenu.stories.tsx
+++ b/src/components/basic/SideMenu/SideMenu.stories.tsx
@@ -20,9 +20,8 @@
 
 import { Box } from '@mui/material'
 import { type ComponentStory } from '@storybook/react'
-
-import { SideMenu as Component } from '.'
 import { DraggableChip } from '../Chip/DraggableChip'
+import { SideMenu as Component } from '.'
 
 export default {
   title: 'Menus',

--- a/src/components/basic/SideMenu/index.tsx
+++ b/src/components/basic/SideMenu/index.tsx
@@ -18,11 +18,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward'
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward'
 import { Box, type BoxProps, Collapse, Fade } from '@mui/material'
 import { useCallback, useEffect, useState } from 'react'
 import { Button } from '../Button'
-import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward'
-import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward'
 
 export interface SideMenuProps extends Omit<BoxProps, 'onChange'> {
   header?: string | JSX.Element

--- a/src/components/basic/SortOption/index.tsx
+++ b/src/components/basic/SortOption/index.tsx
@@ -18,9 +18,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+import { Box } from '@mui/material'
 import { useState } from 'react'
 import { Typography } from '../Typography'
-import { Box } from '@mui/material'
 
 export interface SortOptionsType {
   label: string

--- a/src/components/basic/StaticTable/EditField.tsx
+++ b/src/components/basic/StaticTable/EditField.tsx
@@ -17,11 +17,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { Typography } from '@mui/material'
-import { useState } from 'react'
+import CloseIcon from '@mui/icons-material/Close'
 import EditIcon from '@mui/icons-material/Edit'
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline'
-import CloseIcon from '@mui/icons-material/Close'
+import { Typography } from '@mui/material'
+import { useState } from 'react'
 import { Input } from '../../../main'
 import { Tooltips } from '../ToolTips'
 

--- a/src/components/basic/StaticTable/HorizontalTable.tsx
+++ b/src/components/basic/StaticTable/HorizontalTable.tsx
@@ -18,10 +18,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { Box, Typography } from '@mui/material'
-import { type TableType } from './types'
-import { useState } from 'react'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
+import { Box, Typography } from '@mui/material'
+import { useState } from 'react'
+import { type TableType } from './types'
 
 export const HorizontalTable = ({ data }: { data: TableType }) => {
   const [copied, setCopied] = useState<string>('')

--- a/src/components/basic/StaticTable/StaticTable.stories.tsx
+++ b/src/components/basic/StaticTable/StaticTable.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { StaticTable as Component } from '.'
 
 export default {

--- a/src/components/basic/StaticTable/VerticalTable.tsx
+++ b/src/components/basic/StaticTable/VerticalTable.tsx
@@ -18,16 +18,16 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { useState } from 'react'
-import { Typography, Link, Box } from '@mui/material'
-import EditIcon from '@mui/icons-material/Edit'
-import HelpOutlineIcon from '@mui/icons-material/HelpOutline'
-import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline'
-import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import CloseIcon from '@mui/icons-material/Close'
-import type { TableType } from './types'
+import ContentCopyIcon from '@mui/icons-material/ContentCopy'
+import EditIcon from '@mui/icons-material/Edit'
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline'
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline'
+import { Typography, Link, Box } from '@mui/material'
+import { useState } from 'react'
 import { Input } from '../Input'
 import { Tooltips } from '../ToolTips'
+import type { TableType } from './types'
 
 export const VerticalTable = ({
   data,

--- a/src/components/basic/StaticTable/index.tsx
+++ b/src/components/basic/StaticTable/index.tsx
@@ -19,8 +19,8 @@
  ********************************************************************************/
 
 import { HorizontalTable } from './HorizontalTable'
-import { VerticalTable } from './VerticalTable'
 import type { TableType } from './types'
+import { VerticalTable } from './VerticalTable'
 
 export const StaticTable = ({
   data,

--- a/src/components/basic/Stepper/RoundedStepper.stories.tsx
+++ b/src/components/basic/Stepper/RoundedStepper.stories.tsx
@@ -18,7 +18,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { RoundedStepper as Component } from './RoundedStepper'
 
 export default {

--- a/src/components/basic/Stepper/RoundedStepper.tsx
+++ b/src/components/basic/Stepper/RoundedStepper.tsx
@@ -18,8 +18,8 @@
  ********************************************************************************/
 
 import { Box } from '@mui/material'
-import './RoundedStepper.scss'
 import { RoundedStepperItem } from './RoundedStepperItem'
+import './RoundedStepper.scss'
 
 export interface StepList {
   step: number

--- a/src/components/basic/Stepper/RoundedStepperItem.tsx
+++ b/src/components/basic/Stepper/RoundedStepperItem.tsx
@@ -18,8 +18,8 @@
  ********************************************************************************/
 
 import { Box } from '@mui/material'
-import { Typography } from '../Typography'
 import { theme } from '../../../theme'
+import { Typography } from '../Typography'
 
 interface StepperItemProps {
   color: string

--- a/src/components/basic/Stepper/Stepper.stories.tsx
+++ b/src/components/basic/Stepper/Stepper.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { Stepper as Component } from '.'
 
 export default {

--- a/src/components/basic/Stepper/StepperItem.tsx
+++ b/src/components/basic/Stepper/StepperItem.tsx
@@ -18,10 +18,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { useEffect, useState } from 'react'
 import { Box, Link } from '@mui/material'
-import { Typography } from '../Typography'
+import { useEffect, useState } from 'react'
 import { theme } from '../../../theme'
+import { Typography } from '../Typography'
 
 interface StepperItemProps {
   step: number

--- a/src/components/basic/Stepper/index.tsx
+++ b/src/components/basic/Stepper/index.tsx
@@ -17,9 +17,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp'
 import { Box, Link } from '@mui/material'
 import uniqueId from 'lodash/uniqueId'
-import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp'
 import { Typography } from '../Typography'
 import { StepperItem } from './StepperItem'
 import './Stepper.scss'

--- a/src/components/basic/SubNavigation/ParentSubNavigation.tsx
+++ b/src/components/basic/SubNavigation/ParentSubNavigation.tsx
@@ -18,8 +18,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { Button } from '../Button'
 import EastIcon from '@mui/icons-material/East'
+import { Button } from '../Button'
 
 export interface NavigationItem {
   index: number

--- a/src/components/basic/SubNavigation/SubNavigationButton.tsx
+++ b/src/components/basic/SubNavigation/SubNavigationButton.tsx
@@ -19,8 +19,8 @@
  ********************************************************************************/
 
 import { Box } from '@mui/material'
-import { type SubNavigationProps } from '.'
 import { Button } from '../Button'
+import { type SubNavigationProps } from '.'
 
 export const SubNavigationButton = ({
   buttonLabel,

--- a/src/components/basic/SubNavigation/SubNavigationLink.tsx
+++ b/src/components/basic/SubNavigation/SubNavigationLink.tsx
@@ -18,10 +18,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { Box } from '@mui/material'
-import { type SubNavigationProps } from '.'
-import { Button } from '../Button'
 import EastIcon from '@mui/icons-material/East'
+import { Box } from '@mui/material'
+import { Button } from '../Button'
+import { type SubNavigationProps } from '.'
 
 export const SubNavigationLink = ({
   link1Label,

--- a/src/components/basic/SubNavigation/index.tsx
+++ b/src/components/basic/SubNavigation/index.tsx
@@ -20,8 +20,8 @@
 
 import { Box } from '@mui/material'
 import { theme } from '../../../theme'
-import { SubNavigationLink } from './SubNavigationLink'
 import { SubNavigationButton } from './SubNavigationButton'
+import { SubNavigationLink } from './SubNavigationLink'
 
 export interface SubNavigationProps {
   buttonLabel?: string

--- a/src/components/basic/Table/PageLoadingTable.tsx
+++ b/src/components/basic/Table/PageLoadingTable.tsx
@@ -19,9 +19,9 @@
  ********************************************************************************/
 import { Box } from '@mui/material'
 import { useState, useEffect } from 'react'
-import { Table, type TableProps } from '.'
 import { LoadMoreButton } from '../Button/LoadMoreButton'
 import { hasMorePages, getMaxRows } from './components/Helper/helper'
+import { Table, type TableProps } from '.'
 
 export interface PaginFetchArgs {
   page: number

--- a/src/components/basic/Table/components/Error/Error500Overlay.tsx
+++ b/src/components/basic/Table/components/Error/Error500Overlay.tsx
@@ -18,9 +18,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+import RefreshIcon from '@mui/icons-material/Refresh'
 import { Box } from '@mui/material'
 import { Typography } from '../../../Typography'
-import RefreshIcon from '@mui/icons-material/Refresh'
 
 const flexColumn = {
   display: 'flex',

--- a/src/components/basic/Table/components/Toolbar/SearchAndFilterButtonToolbar.tsx
+++ b/src/components/basic/Table/components/Toolbar/SearchAndFilterButtonToolbar.tsx
@@ -18,17 +18,17 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 import ClearIcon from '@mui/icons-material/Clear'
-import React, { useState, useMemo, useCallback } from 'react'
 import { Box, useTheme, debounce } from '@mui/material'
-import { SearchInput } from '../../../SearchInput'
+import React, { useState, useMemo, useCallback } from 'react'
 import { IconButton } from '../../../IconButton'
-import { type ToolbarProps } from '.'
+import { SearchInput } from '../../../SearchInput'
+import { SortOption, type SortOptionsType } from '../../../SortOption'
+import { Typography } from '../../../Typography'
 import { ViewSelector } from '../../../ViewSelector'
 import type { View } from '../../../ViewSelector'
-import { Typography } from '../../../Typography'
-import type { SelectedFilter } from './UltimateToolbar'
-import { SortOption, type SortOptionsType } from '../../../SortOption'
 import SortImage from './SortImage'
+import type { SelectedFilter } from './UltimateToolbar'
+import { type ToolbarProps } from '.'
 
 export interface SearchAndFilterButtonToolbarProps extends ToolbarProps {
   placeholder?: string

--- a/src/components/basic/Table/components/Toolbar/UltimateToolbar.tsx
+++ b/src/components/basic/Table/components/Toolbar/UltimateToolbar.tsx
@@ -18,11 +18,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 import ClearIcon from '@mui/icons-material/Clear'
-import React, { useState, useMemo, useCallback } from 'react'
 import { Box, useTheme, debounce } from '@mui/material'
+import React, { useState, useMemo, useCallback } from 'react'
 import { Button } from '../../../Button'
-import { SearchInput } from '../../../SearchInput'
 import { IconButton } from '../../../IconButton'
+import { SearchInput } from '../../../SearchInput'
 import { type ToolbarProps } from '.'
 
 export type SelectedFilter = Record<string, string[]>

--- a/src/components/basic/Table/components/Toolbar/index.tsx
+++ b/src/components/basic/Table/components/Toolbar/index.tsx
@@ -18,19 +18,19 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline'
+import ClearIcon from '@mui/icons-material/Clear'
+import FilterIcon from '@mui/icons-material/FilterAltOutlined'
+import SearchIcon from '@mui/icons-material/Search'
 import { Box, debounce, useTheme } from '@mui/material'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { Button } from '../../../Button'
+import { Checkbox } from '../../../Checkbox'
 import { IconButton } from '../../../IconButton'
 import { SearchInput } from '../../../SearchInput'
-import { Typography } from '../../../Typography'
-import SearchIcon from '@mui/icons-material/Search'
-import FilterIcon from '@mui/icons-material/FilterAltOutlined'
-import ClearIcon from '@mui/icons-material/Clear'
-import { Checkbox } from '../../../Checkbox'
-import { getSelectedFilterUpdate } from './helper'
-import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline'
 import { Tooltips } from '../../../ToolTips'
+import { Typography } from '../../../Typography'
+import { getSelectedFilterUpdate } from './helper'
 
 interface FilterValue {
   value: string

--- a/src/components/basic/Table/index.tsx
+++ b/src/components/basic/Table/index.tsx
@@ -18,29 +18,29 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { useCallback } from 'react'
+import { Box, Stack } from '@mui/material'
 import {
   DataGrid,
   type GridRowSelectionModel,
   type DataGridProps,
   type GridRowId,
 } from '@mui/x-data-grid'
-import { Box, Stack } from '@mui/material'
+import { useCallback } from 'react'
+import { theme } from '../../../theme'
+import { LoadMoreButton } from '../Button/LoadMoreButton'
+import { type SortOptionsType } from '../SortOption'
+import { Typography } from '../Typography'
+import type { View } from '../ViewSelector'
+import { Error400Overlay } from './components/Error/Error400Overlay'
+import { Error500Overlay } from './components/Error/Error500Overlay'
 import { StatusTag } from './components/StatusTag'
 import {
   type AdditionalButtonsType,
   Toolbar,
   type ToolbarProps,
 } from './components/Toolbar'
-import { UltimateToolbar } from './components/Toolbar/UltimateToolbar'
-import { theme } from '../../../theme'
 import { SearchAndFilterButtonToolbar } from './components/Toolbar/SearchAndFilterButtonToolbar'
-import { Typography } from '../Typography'
-import { Error500Overlay } from './components/Error/Error500Overlay'
-import { Error400Overlay } from './components/Error/Error400Overlay'
-import type { View } from '../ViewSelector'
-import { type SortOptionsType } from '../SortOption'
-import { LoadMoreButton } from '../Button/LoadMoreButton'
+import { UltimateToolbar } from './components/Toolbar/UltimateToolbar'
 
 export { StatusTag }
 export type toolbarType = 'basic' | 'premium' | 'ultimate' | 'searchAndFilter'

--- a/src/components/basic/Table/table.stories.tsx
+++ b/src/components/basic/Table/table.stories.tsx
@@ -18,16 +18,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
-
-import { Table as Component } from '.'
+import Link from '@mui/material/Link'
 import type {
   GridColDef,
   GridRowsProp,
   GridRenderCellParams,
 } from '@mui/x-data-grid'
-import Link from '@mui/material/Link'
+import { type ComponentStory } from '@storybook/react'
 import TestRows from '../../../../src/assets/data/TableRows.json'
+import { Table as Component } from '.'
 
 const rows: GridRowsProp = TestRows
 

--- a/src/components/basic/Tabs/TabPanel.tsx
+++ b/src/components/basic/Tabs/TabPanel.tsx
@@ -18,8 +18,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import React from 'react'
 import { Box } from '@mui/material'
+import React from 'react'
 
 interface TabPanelProps {
   children?: React.ReactNode

--- a/src/components/basic/Tabs/Tabs.stories.tsx
+++ b/src/components/basic/Tabs/Tabs.stories.tsx
@@ -18,16 +18,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
-
 import GroupOutlinedIcon from '@mui/icons-material/GroupOutlined'
 import PersonOutlinedIcon from '@mui/icons-material/PersonOutlined'
-import React from 'react'
 import { Box } from '@mui/material'
-import { type ReactComponent } from '*.svg'
+import { type ComponentStory } from '@storybook/react'
+import React from 'react'
 import { Tab } from './Tab'
 import { TabPanel } from './TabPanel'
 import { Tabs } from './Tabs'
+import { type ReactComponent } from '*.svg'
 
 export default {
   title: 'Tabs',

--- a/src/components/basic/Textarea/Textarea.stories.tsx
+++ b/src/components/basic/Textarea/Textarea.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { Textarea as Component } from '.'
 
 export default {

--- a/src/components/basic/ToggleSwitch/ToggleSwitch.stories.tsx
+++ b/src/components/basic/ToggleSwitch/ToggleSwitch.stories.tsx
@@ -18,8 +18,8 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-import { ToggleSwitch as Component } from '.'
 import { useState } from 'react'
+import { ToggleSwitch as Component } from '.'
 
 export default {
   title: 'ToggleSwitch',

--- a/src/components/basic/ToggleSwitch/index.tsx
+++ b/src/components/basic/ToggleSwitch/index.tsx
@@ -17,9 +17,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+import { Switch, Tooltip } from '@mui/material'
 import React from 'react'
 import './ToggleSwitch.scss'
-import { Switch, Tooltip } from '@mui/material'
 
 export interface ToggleSwitchProps {
   checked: boolean

--- a/src/components/basic/ToolTips/ToolTips.stories.tsx
+++ b/src/components/basic/ToolTips/ToolTips.stories.tsx
@@ -20,8 +20,8 @@
 
 import { Box } from '@mui/material'
 import { type ComponentStory } from '@storybook/react'
-import { Tooltips as Component } from '.'
 import { Button } from '../Button'
+import { Tooltips as Component } from '.'
 
 export default {
   title: 'Tooltips',

--- a/src/components/basic/UserAvatar/UserAvatar.stories.tsx
+++ b/src/components/basic/UserAvatar/UserAvatar.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { UserAvatar as Component } from '.'
 
 export default {

--- a/src/components/basic/UserAvatar/index.tsx
+++ b/src/components/basic/UserAvatar/index.tsx
@@ -18,8 +18,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { Badge, Avatar, type AvatarProps, useTheme } from '@mui/material'
 import PersonOutlineIcon from '@mui/icons-material/PersonOutline'
+import { Badge, Avatar, type AvatarProps, useTheme } from '@mui/material'
 
 interface AllAvatarProps extends Omit<AvatarProps, 'ImageComponent'> {
   altText?: string

--- a/src/components/basic/VerticalTabs/VerticalTabs.stories.tsx
+++ b/src/components/basic/VerticalTabs/VerticalTabs.stories.tsx
@@ -18,9 +18,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ComponentStory } from '@storybook/react'
 import { Box, Typography } from '@mui/material'
-
+import { type ComponentStory } from '@storybook/react'
 import { type TabPanelType, VerticalTabs as Component } from '.'
 
 export default {

--- a/src/components/basic/VerticalTabs/index.tsx
+++ b/src/components/basic/VerticalTabs/index.tsx
@@ -18,12 +18,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { Box, useTheme } from '@mui/material'
-import Tabs from '@mui/material/Tabs'
-import Tab from '@mui/material/Tab'
-import { useState } from 'react'
-import uniqueId from 'lodash/uniqueId'
 import ArrowForwardIos from '@mui/icons-material/ArrowForwardIos'
+import { Box, useTheme } from '@mui/material'
+import Tab from '@mui/material/Tab'
+import Tabs from '@mui/material/Tabs'
+import uniqueId from 'lodash/uniqueId'
+import { useState } from 'react'
 
 export interface TabPanelType {
   id: number

--- a/src/components/basic/ViewSelector/index.tsx
+++ b/src/components/basic/ViewSelector/index.tsx
@@ -19,8 +19,8 @@
  ********************************************************************************/
 
 import { Box } from '@mui/material'
-import { Button } from '../Button'
 import React from 'react'
+import { Button } from '../Button'
 
 export interface View {
   buttonText: string

--- a/src/components/content/Cards/AboutCard.stories.tsx
+++ b/src/components/content/Cards/AboutCard.stories.tsx
@@ -18,7 +18,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { AboutCard as Component } from './AboutCard'
 
 export default {

--- a/src/components/content/Cards/Card.tsx
+++ b/src/components/content/Cards/Card.tsx
@@ -18,18 +18,18 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { Box, Link, Typography, useTheme } from '@mui/material'
+import FavoriteIcon from '@mui/icons-material/Favorite'
 import MoreVertIcon from '@mui/icons-material/MoreVert'
+import { Box, Link, Typography, useTheme } from '@mui/material'
 import { useEffect, useRef, useState } from 'react'
+import { Chip } from '../../basic/Chip'
+import { SortOption } from '../../basic/SortOption'
+import { Tooltips } from '../../basic/ToolTips'
 import { CardButtons, type CardButtonsProps } from './CardButtons'
 import { CardChip, type CardChipProps } from './CardChip'
 import { CardContent, type CardContentProps } from './CardContent'
 import { CardImage, type CardImageProps } from './CardImage'
-import { SortOption } from '../../basic/SortOption'
 import { type SubItems } from '.'
-import { Tooltips } from '../../basic/ToolTips'
-import FavoriteIcon from '@mui/icons-material/Favorite'
-import { Chip } from '../../basic/Chip'
 
 type Variants =
   | 'minimal'

--- a/src/components/content/Cards/CardAddService.tsx
+++ b/src/components/content/Cards/CardAddService.tsx
@@ -19,8 +19,8 @@
  ********************************************************************************/
 
 import { Box, useTheme } from '@mui/material'
-import { Typography } from '../../basic/Typography'
 import { useState, useEffect, useRef } from 'react'
+import { Typography } from '../../basic/Typography'
 
 export interface CardAddServiceProps {
   title?: string

--- a/src/components/content/Cards/CardButtons.tsx
+++ b/src/components/content/Cards/CardButtons.tsx
@@ -18,11 +18,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+import AddIcon from '@mui/icons-material/Add'
+import CheckIcon from '@mui/icons-material/Check'
 import { Box } from '@mui/material'
 import { Button } from '../../basic/Button'
 import { IconButton } from '../../basic/IconButton'
-import AddIcon from '@mui/icons-material/Add'
-import CheckIcon from '@mui/icons-material/Check'
 
 export interface CardButtonsProps {
   buttonText: string

--- a/src/components/content/Cards/CardDecision.stories.tsx
+++ b/src/components/content/Cards/CardDecision.stories.tsx
@@ -20,7 +20,6 @@
 
 import { type ComponentStory } from '@storybook/react'
 import { StatusVariants } from './CardChip'
-
 import { CardDecision as Component } from './CardDecision'
 
 export default {

--- a/src/components/content/Cards/CardDecision.tsx
+++ b/src/components/content/Cards/CardDecision.tsx
@@ -18,10 +18,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+import ApprovalIcon from '@mui/icons-material/Approval'
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 import { Box, Typography, IconButton, useTheme } from '@mui/material'
 import { CardChip, StatusVariants, type Variants } from './CardChip'
-import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
-import ApprovalIcon from '@mui/icons-material/Approval'
 
 export interface AppContent {
   appId?: string

--- a/src/components/content/Cards/CardHorizontal.stories.tsx
+++ b/src/components/content/Cards/CardHorizontal.stories.tsx
@@ -20,7 +20,6 @@
 
 import { type ComponentStory } from '@storybook/react'
 import { StatusVariants } from './CardChip'
-
 import { CardHorizontal as Component } from './CardHorizontal'
 
 export default {

--- a/src/components/content/Cards/CardHorizontal.tsx
+++ b/src/components/content/Cards/CardHorizontal.tsx
@@ -18,9 +18,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { useRef } from 'react'
-import { Box, useTheme } from '@mui/material'
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown'
+import { Box, useTheme } from '@mui/material'
+import { useRef } from 'react'
 import { LogoGrayData } from '../../basic/Image'
 import { Typography } from '../../basic/Typography'
 import { type CardChipProps } from './CardChip'

--- a/src/components/content/Cards/CardRating.tsx
+++ b/src/components/content/Cards/CardRating.tsx
@@ -18,9 +18,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+import StarRateIcon from '@mui/icons-material/StarRate'
 import { Box, useTheme } from '@mui/material'
 import { Typography } from '../../basic/Typography'
-import StarRateIcon from '@mui/icons-material/StarRate'
 
 export interface CardRatingProps {
   rating: number

--- a/src/components/content/Cards/ContentCard.stories.tsx
+++ b/src/components/content/Cards/ContentCard.stories.tsx
@@ -18,7 +18,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { ContentCard as Component } from './ContentCard'
 
 export default {

--- a/src/components/content/Cards/MarketplaceCard.stories.tsx
+++ b/src/components/content/Cards/MarketplaceCard.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { Cards as Component } from '.'
 
 export default {

--- a/src/components/content/Cards/index.tsx
+++ b/src/components/content/Cards/index.tsx
@@ -19,8 +19,8 @@
  ********************************************************************************/
 
 import { Box } from '@mui/material'
-import { Card, type CardProps } from './Card'
 import uniqueId from 'lodash/uniqueId'
+import { Card, type CardProps } from './Card'
 import { CardAddService } from './CardAddService'
 
 export type CardItems = Omit<

--- a/src/components/content/DemoComponents/CardGrid.stories.tsx
+++ b/src/components/content/DemoComponents/CardGrid.stories.tsx
@@ -17,8 +17,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { CardGrid as Component } from './CardGrid'
 import type { Meta, StoryObj } from '@storybook/react'
+import { CardGrid as Component } from './CardGrid'
 
 const meta: Meta<typeof Component> = {
   component: Component,

--- a/src/components/content/DemoComponents/CardGrid.tsx
+++ b/src/components/content/DemoComponents/CardGrid.tsx
@@ -17,13 +17,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+import { Box } from '@mui/material'
 import { CardWithImage } from './components/CardWithImage'
 import { CardWithoutImage } from './components/CardWithoutImage'
 import {
   type ProviderProps,
   type CardDetailsProps,
 } from './ContentComponentsTypes'
-import { Box } from '@mui/material'
 import './ContentComponents.scss'
 
 export const CardGrid = ({

--- a/src/components/content/DemoComponents/FlexImages.stories.tsx
+++ b/src/components/content/DemoComponents/FlexImages.stories.tsx
@@ -17,8 +17,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { FlexImages as Component } from './FlexImages'
 import type { Meta, StoryObj } from '@storybook/react'
+import { FlexImages as Component } from './FlexImages'
 
 const meta: Meta<typeof Component> = {
   component: Component,

--- a/src/components/content/DemoComponents/FlexImages.tsx
+++ b/src/components/content/DemoComponents/FlexImages.tsx
@@ -17,9 +17,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+import { RenderImage } from './components/RenderImage'
 import { type ProviderProps } from './ContentComponentsTypes'
 import './ContentComponents.scss'
-import { RenderImage } from './components/RenderImage'
 
 export const FlexImages = ({
   provider,

--- a/src/components/content/DemoComponents/GridImages.stories.tsx
+++ b/src/components/content/DemoComponents/GridImages.stories.tsx
@@ -17,8 +17,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { GridImages as Component } from './GridImages'
 import type { Meta, StoryObj } from '@storybook/react'
+import { GridImages as Component } from './GridImages'
 
 const meta: Meta<typeof Component> = {
   component: Component,

--- a/src/components/content/DemoComponents/GridImages.tsx
+++ b/src/components/content/DemoComponents/GridImages.tsx
@@ -17,10 +17,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+import { Box } from '@mui/material'
+import { RenderImage } from './components/RenderImage'
 import { type ProviderProps } from './ContentComponentsTypes'
 import './ContentComponents.scss'
-import { RenderImage } from './components/RenderImage'
-import { Box } from '@mui/material'
 
 export const GridImages = ({
   provider,

--- a/src/components/content/DemoComponents/LinkButtonGrid.stories.tsx
+++ b/src/components/content/DemoComponents/LinkButtonGrid.stories.tsx
@@ -17,8 +17,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { LinkButtonGrid as Component } from './LinkButtonGrid'
 import type { Meta, StoryObj } from '@storybook/react'
+import { LinkButtonGrid as Component } from './LinkButtonGrid'
 
 const meta: Meta<typeof Component> = {
   component: Component,

--- a/src/components/content/DemoComponents/LinkButtonGrid.tsx
+++ b/src/components/content/DemoComponents/LinkButtonGrid.tsx
@@ -17,9 +17,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ProviderProps, type LinkProps } from './ContentComponentsTypes'
 import { Box } from '@mui/material'
 import { Typography } from '../../basic/Typography'
+import { type ProviderProps, type LinkProps } from './ContentComponentsTypes'
 import './ContentComponents.scss'
 
 export const LinkButtonGrid = ({

--- a/src/components/content/DemoComponents/TextCenterAligned.stories.tsx
+++ b/src/components/content/DemoComponents/TextCenterAligned.stories.tsx
@@ -17,8 +17,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { TextCenterAligned as Component } from './TextCenterAligned'
 import type { Meta, StoryObj } from '@storybook/react'
+import { TextCenterAligned as Component } from './TextCenterAligned'
 
 const meta: Meta<typeof Component> = {
   component: Component,

--- a/src/components/content/DemoComponents/TextCenterAligned.tsx
+++ b/src/components/content/DemoComponents/TextCenterAligned.tsx
@@ -17,12 +17,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { Typography } from '../../basic/Typography'
-import { IconButton } from '../../basic/IconButton'
-import { type ProviderProps } from './ContentComponentsTypes'
-import './ContentComponents.scss'
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward'
 import { Trans } from 'react-i18next'
+import { IconButton } from '../../basic/IconButton'
+import { Typography } from '../../basic/Typography'
+import { type ProviderProps } from './ContentComponentsTypes'
+import './ContentComponents.scss'
 
 export const TextCenterAligned = ({
   provider,

--- a/src/components/content/DemoComponents/TextCenterAlignedBody2.stories.tsx
+++ b/src/components/content/DemoComponents/TextCenterAlignedBody2.stories.tsx
@@ -17,8 +17,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { TextCenterAlignedBody2 as Component } from './TextCenterAlignedBody2'
 import type { Meta, StoryObj } from '@storybook/react'
+import { TextCenterAlignedBody2 as Component } from './TextCenterAlignedBody2'
 
 const meta: Meta<typeof Component> = {
   component: Component,

--- a/src/components/content/DemoComponents/TextCenterAlignedBody2.tsx
+++ b/src/components/content/DemoComponents/TextCenterAlignedBody2.tsx
@@ -17,13 +17,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward'
 import { Box } from '@mui/material'
+import { Trans } from 'react-i18next'
+import { IconButton } from '../../basic/IconButton'
+import { Typography } from '../../basic/Typography'
 import { type ProviderProps } from './ContentComponentsTypes'
 import './ContentComponents.scss'
-import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward'
-import { Trans } from 'react-i18next'
-import { Typography } from '../../basic/Typography'
-import { IconButton } from '../../basic/IconButton'
 
 export const TextCenterAlignedBody2 = ({
   provider,

--- a/src/components/content/DemoComponents/TextImageCenterAligned.stories.tsx
+++ b/src/components/content/DemoComponents/TextImageCenterAligned.stories.tsx
@@ -17,8 +17,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { TextImageCenterAligned as Component } from './TextImageCenterAligned'
 import type { Meta, StoryObj } from '@storybook/react'
+import { TextImageCenterAligned as Component } from './TextImageCenterAligned'
 
 const meta: Meta<typeof Component> = {
   component: Component,

--- a/src/components/content/DemoComponents/TextImageCenterAligned.tsx
+++ b/src/components/content/DemoComponents/TextImageCenterAligned.tsx
@@ -17,10 +17,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ProviderProps } from './ContentComponentsTypes'
-import './ContentComponents.scss'
 import { RenderImage } from './components/RenderImage'
+import { type ProviderProps } from './ContentComponentsTypes'
 import { TextCenterAligned } from './TextCenterAligned'
+import './ContentComponents.scss'
 
 export const TextImageCenterAligned = ({
   provider,

--- a/src/components/content/DemoComponents/TextImageSideBySide.stories.tsx
+++ b/src/components/content/DemoComponents/TextImageSideBySide.stories.tsx
@@ -17,8 +17,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { TextImageSideBySide as Component } from './TextImageSideBySide'
 import type { Meta, StoryObj } from '@storybook/react'
+import { TextImageSideBySide as Component } from './TextImageSideBySide'
 
 const meta: Meta<typeof Component> = {
   component: Component,

--- a/src/components/content/DemoComponents/TextImageSideBySide.tsx
+++ b/src/components/content/DemoComponents/TextImageSideBySide.tsx
@@ -17,10 +17,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ProviderProps } from './ContentComponentsTypes'
-import './ContentComponents.scss'
 import { ImageVideoWrapper } from './components/ImageVideoWrapper'
 import { RenderImage } from './components/RenderImage'
+import { type ProviderProps } from './ContentComponentsTypes'
+import './ContentComponents.scss'
 
 export const TextImageSideBySide = ({
   provider,

--- a/src/components/content/DemoComponents/TextImageSideBySideWithSections.stories.tsx
+++ b/src/components/content/DemoComponents/TextImageSideBySideWithSections.stories.tsx
@@ -17,8 +17,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { TextImageSideBySideWithSections as Component } from './TextImageSideBySideWithSections'
 import type { Meta, StoryObj } from '@storybook/react'
+import { TextImageSideBySideWithSections as Component } from './TextImageSideBySideWithSections'
 
 const meta: Meta<typeof Component> = {
   component: Component,

--- a/src/components/content/DemoComponents/TextImageSideBySideWithSections.tsx
+++ b/src/components/content/DemoComponents/TextImageSideBySideWithSections.tsx
@@ -17,18 +17,18 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import {
-  type CardDetailsProps,
-  type ProviderProps,
-} from './ContentComponentsTypes'
-import './ContentComponents.scss'
-import { Trans } from 'react-i18next'
 import { Box, useMediaQuery, useTheme } from '@mui/material'
+import { Trans } from 'react-i18next'
 import { Typography } from '../../basic/Typography'
 import { AlignedText } from './components/AlignedText'
 import { CardWithoutImage } from './components/CardWithoutImage'
 import { RenderImage } from './components/RenderImage'
 import { TitleDescriptionAndSectionlink } from './components/TitleDescriptionAndSectionlink'
+import {
+  type CardDetailsProps,
+  type ProviderProps,
+} from './ContentComponentsTypes'
+import './ContentComponents.scss'
 
 export const TextImageSideBySideWithSections = ({
   provider,

--- a/src/components/content/DemoComponents/TextVideoSideBySide.stories.tsx
+++ b/src/components/content/DemoComponents/TextVideoSideBySide.stories.tsx
@@ -17,8 +17,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { TextVideoSideBySide as Component } from './TextVideoSideBySide'
 import type { Meta, StoryObj } from '@storybook/react'
+import { TextVideoSideBySide as Component } from './TextVideoSideBySide'
 
 const meta: Meta<typeof Component> = {
   component: Component,

--- a/src/components/content/DemoComponents/TextVideoSideBySide.tsx
+++ b/src/components/content/DemoComponents/TextVideoSideBySide.tsx
@@ -17,10 +17,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ProviderProps } from './ContentComponentsTypes'
-import './ContentComponents.scss'
 import ReactPlayer from 'react-player'
 import { ImageVideoWrapper } from './components/ImageVideoWrapper'
+import { type ProviderProps } from './ContentComponentsTypes'
+import './ContentComponents.scss'
 
 export const TextVideoSideBySide = ({
   provider,

--- a/src/components/content/DemoComponents/VideoTextSideBySide.stories.tsx
+++ b/src/components/content/DemoComponents/VideoTextSideBySide.stories.tsx
@@ -17,8 +17,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { VideoTextSideBySide as Component } from './VideoTextSideBySide'
 import type { Meta, StoryObj } from '@storybook/react'
+import { VideoTextSideBySide as Component } from './VideoTextSideBySide'
 
 const meta: Meta<typeof Component> = {
   component: Component,

--- a/src/components/content/DemoComponents/VideoTextSideBySide.tsx
+++ b/src/components/content/DemoComponents/VideoTextSideBySide.tsx
@@ -17,13 +17,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ProviderProps } from './ContentComponentsTypes'
-import './ContentComponents.scss'
-import ReactPlayer from 'react-player'
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward'
 import { Trans } from 'react-i18next'
-import { Typography } from '../../basic/Typography'
+import ReactPlayer from 'react-player'
 import { IconButton } from '../../basic/IconButton'
+import { Typography } from '../../basic/Typography'
+import { type ProviderProps } from './ContentComponentsTypes'
+import './ContentComponents.scss'
 
 export const VideoTextSideBySide = ({
   provider,

--- a/src/components/content/DemoComponents/components/AlignedText.tsx
+++ b/src/components/content/DemoComponents/components/AlignedText.tsx
@@ -18,8 +18,8 @@
  ********************************************************************************/
 
 import { type SubSectionsType } from '../ContentComponentsTypes'
-import '../ContentComponents.scss'
 import { TitleDescriptionAndSectionlink } from './TitleDescriptionAndSectionlink'
+import '../ContentComponents.scss'
 
 export const AlignedText = ({
   provider,

--- a/src/components/content/DemoComponents/components/CardWithImage.tsx
+++ b/src/components/content/DemoComponents/components/CardWithImage.tsx
@@ -17,11 +17,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { CardWithText } from './CardWithText'
 import { Box } from '@mui/material'
-import '../ContentComponents.scss'
 import { Image } from '../../../basic/Image'
 import { type CardDetailsProps } from '../ContentComponentsTypes'
+import { CardWithText } from './CardWithText'
+import '../ContentComponents.scss'
 
 export const CardWithImage = ({
   detail,

--- a/src/components/content/DemoComponents/components/CardWithText.tsx
+++ b/src/components/content/DemoComponents/components/CardWithText.tsx
@@ -17,10 +17,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type CardDetailsProps } from '../ContentComponentsTypes'
-import '../ContentComponents.scss'
 import { Trans } from 'react-i18next'
 import { Typography } from '../../../basic/Typography'
+import { type CardDetailsProps } from '../ContentComponentsTypes'
+import '../ContentComponents.scss'
 
 export const CardWithText = ({
   card,

--- a/src/components/content/DemoComponents/components/CardWithoutImage.tsx
+++ b/src/components/content/DemoComponents/components/CardWithoutImage.tsx
@@ -17,9 +17,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+import { Box } from '@mui/material'
 import { type CardDetailsProps } from '../ContentComponentsTypes'
 import { CardWithText } from './CardWithText'
-import { Box } from '@mui/material'
 import '../ContentComponents.scss'
 
 export const CardWithoutImage = ({

--- a/src/components/content/DemoComponents/components/ImageTextSideBySide.tsx
+++ b/src/components/content/DemoComponents/components/ImageTextSideBySide.tsx
@@ -17,13 +17,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { IconButton } from '../../../basic/IconButton'
-import { type ProviderProps } from '../ContentComponentsTypes'
-import '../ContentComponents.scss'
-import { RenderImage } from './RenderImage'
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward'
 import { Trans } from 'react-i18next'
+import { IconButton } from '../../../basic/IconButton'
 import { Typography } from '../../../basic/Typography'
+import { type ProviderProps } from '../ContentComponentsTypes'
+import { RenderImage } from './RenderImage'
+import '../ContentComponents.scss'
 
 export const ImageTextSideBySide = ({
   provider,

--- a/src/components/content/DemoComponents/components/RenderImage.tsx
+++ b/src/components/content/DemoComponents/components/RenderImage.tsx
@@ -18,8 +18,8 @@
  ********************************************************************************/
 
 import { useMediaQuery } from '@mui/material'
-import '../ContentComponents.scss'
 import { ImageItem } from '../../../basic/ImageGallery/ImageItem'
+import '../ContentComponents.scss'
 
 export const RenderImage = ({
   url,

--- a/src/components/content/DemoComponents/components/TitleDescriptionAndSectionlink.tsx
+++ b/src/components/content/DemoComponents/components/TitleDescriptionAndSectionlink.tsx
@@ -17,15 +17,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import '../ContentComponents.scss'
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward'
 import { Trans } from 'react-i18next'
+import { IconButton } from '../../../basic/IconButton'
+import { Typography } from '../../../basic/Typography'
 import {
   type ProviderProps,
   type SubSectionsType,
 } from '../ContentComponentsTypes'
-import { Typography } from '../../../basic/Typography'
-import { IconButton } from '../../../basic/IconButton'
+import '../ContentComponents.scss'
 
 export const TitleDescriptionAndSectionlink = ({
   scrollTop,

--- a/src/components/content/DemoComponents/index.tsx
+++ b/src/components/content/DemoComponents/index.tsx
@@ -17,11 +17,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { type ProviderProps, TemplateNames } from './ContentComponentsTypes'
-import './ContentComponents.scss'
-import { useState } from 'react'
 import { useMediaQuery, useTheme } from '@mui/material'
+import { useState } from 'react'
 import { CardGrid } from './CardGrid'
+import { ImageTextCenterAligned } from './components/ImageTextCenterAligned'
+import { type ProviderProps, TemplateNames } from './ContentComponentsTypes'
 import { FlexImages } from './FlexImages'
 import { GridImages } from './GridImages'
 import { LinkButtonGrid } from './LinkButtonGrid'
@@ -32,7 +32,7 @@ import { TextImageSideBySide } from './TextImageSideBySide'
 import { TextImageSideBySideWithSections } from './TextImageSideBySideWithSections'
 import { TextVideoSideBySide } from './TextVideoSideBySide'
 import { VideoTextSideBySide } from './VideoTextSideBySide'
-import { ImageTextCenterAligned } from './components/ImageTextCenterAligned'
+import './ContentComponents.scss'
 
 const TemplateConfig = ({
   provider,

--- a/src/components/content/Navigation/NavItem.tsx
+++ b/src/components/content/Navigation/NavItem.tsx
@@ -19,8 +19,8 @@
  ********************************************************************************/
 
 import { Box, Link, useTheme } from '@mui/material'
-import { useState } from 'react'
 import classNames from 'classnames'
+import { useState } from 'react'
 import { Menu } from '../../basic/Menu'
 import { type MenuItemProps } from '../../basic/Menu/MenuItem'
 

--- a/src/components/content/Navigation/Navigation.stories.tsx
+++ b/src/components/content/Navigation/Navigation.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { Navigation as Component } from '.'
 
 export default {

--- a/src/components/content/UserMenu/UserMenu.stories.tsx
+++ b/src/components/content/UserMenu/UserMenu.stories.tsx
@@ -19,10 +19,9 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
-import { UserMenu as Component } from '.'
 import { LanguageSwitch } from '../../basic/LanguageSwitch'
 import { UserNav } from '../UserNav'
+import { UserMenu as Component } from '.'
 
 export default {
   title: 'UserMenu',

--- a/src/components/content/UserMenu/index.tsx
+++ b/src/components/content/UserMenu/index.tsx
@@ -19,9 +19,9 @@
  ********************************************************************************/
 
 import { Box, ClickAwayListener, useTheme } from '@mui/material'
-import { Typography } from '../../basic/Typography'
 import { type Theme } from '@mui/material/styles'
 import { type SxProps } from '@mui/system'
+import { Typography } from '../../basic/Typography'
 
 interface UserMenuProps {
   open: boolean

--- a/src/components/content/UserNav/UserNav.stories.tsx
+++ b/src/components/content/UserNav/UserNav.stories.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ComponentStory } from '@storybook/react'
-
 import { UserNav as Component } from '.'
 
 export default {

--- a/src/test/testUtils.tsx
+++ b/src/test/testUtils.tsx
@@ -17,13 +17,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import React, { type ReactElement } from 'react'
-import { SharedThemeProvider } from '../components'
 import {
   render as rtlRender,
   type RenderOptions,
   type RenderResult,
 } from '@testing-library/react'
+import React, { type ReactElement } from 'react'
+import { SharedThemeProvider } from '../components'
 
 const AllTheProviders = ({ children }: { children: React.ReactNode }) => {
   return <SharedThemeProvider>{children}</SharedThemeProvider>

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -20,7 +20,6 @@
 import { createTheme } from '@mui/material/styles'
 // Needs to use like this to overwrite data grid styles
 // https://mui.com/components/data-grid/getting-started/#typescript
-
 import type {} from '@mui/x-data-grid/themeAugmentation'
 import createPalette from '@mui/material/styles/createPalette'
 import createTypography from '@mui/material/styles/createTypography'


### PR DESCRIPTION
## Description

- ESLint configuration is updated to include the import/order rule with the specified import order.
- Imports throughout the codebase are organized according to the defined order.

## Why

- Improved code readability and consistency.

## Issue

#307

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally