### PR TITLE
refactor: remove use of 'any' type

### DIFF
--- a/src/components/basic/Dialog/index.tsx
+++ b/src/components/basic/Dialog/index.tsx
@@ -19,10 +19,10 @@
  ********************************************************************************/
 
 import { useTheme, useMediaQuery, type Theme } from '@mui/material'
-import { type SystemStyleObject } from '@mui/system'
 import MuiDialog, {
   type DialogProps as MuiDialogProps,
 } from '@mui/material/Dialog'
+import { type SystemStyleObject } from '@mui/system'
 
 export const CONTENT_SPACING_RIGHT_LEFT = 10
 const MODAL_DEFAULT_WIDTH = '1000px'

--- a/src/components/basic/Dialog/index.tsx
+++ b/src/components/basic/Dialog/index.tsx
@@ -18,7 +18,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { useTheme, useMediaQuery } from '@mui/material'
+import { useTheme, useMediaQuery, type Theme } from '@mui/material'
+import { type SystemStyleObject } from '@mui/system'
 import MuiDialog, {
   type DialogProps as MuiDialogProps,
 } from '@mui/material/Dialog'
@@ -28,8 +29,7 @@ const MODAL_DEFAULT_WIDTH = '1000px'
 
 interface AddtionalDialogProps {
   modalBorderRadius?: number
-  // eslint-disable-next-line
-  additionalModalRootStyles?: any
+  additionalModalRootStyles?: SystemStyleObject<Theme>
 }
 
 export type DialogProps = Pick<

--- a/src/components/basic/Dropzone/components/DropPreviewFile.tsx
+++ b/src/components/basic/Dropzone/components/DropPreviewFile.tsx
@@ -125,16 +125,14 @@ export const DropPreviewFile: FunctionComponent<DropPreviewFileProps> = ({
         position: 'relative',
         '&:before': {
           zIndex: -2,
-          // eslint-disable-next-line quotes
-          content: "''",
+          content: '""',
           position: 'absolute',
           inset: 0,
           backgroundColor: 'selected.hover',
         },
         '&:after': {
           zIndex: -1,
-          // eslint-disable-next-line quotes
-          content: "''",
+          content: '""',
           pointerEvents: 'none',
           position: 'absolute',
           inset: 0,

--- a/src/components/basic/ImageGallery/types.ts
+++ b/src/components/basic/ImageGallery/types.ts
@@ -18,6 +18,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+import { type CSSProperties } from 'react'
+
 export interface ImageType {
   url: string
   text: string
@@ -36,6 +38,5 @@ export interface ImageType {
   modalWidth?: string
   width?: string
   height?: string
-  // eslint-disable-next-line
-  additionalStyles?: any
+  additionalStyles?: CSSProperties
 }

--- a/src/components/basic/MultiSelectList/index.tsx
+++ b/src/components/basic/MultiSelectList/index.tsx
@@ -38,6 +38,8 @@ export interface PartsType {
 }
 export type IHashMap<T> = Record<string, T>
 
+type Options = Array<IHashMap<string>>
+
 export interface MultiSelectListProps
   extends Omit<TextFieldProps, 'variant' | 'size'> {
   items: []
@@ -53,7 +55,7 @@ export interface MultiSelectListProps
   tagSize?: TagSizeType
   filterOptionsArgs?: IHashMap<string>
   defaultValues?: []
-  onAddItem: (items: []) => void
+  onAddItem: (items: Options) => void
 }
 
 export const MultiSelectList = ({
@@ -79,12 +81,10 @@ export const MultiSelectList = ({
 }: MultiSelectListProps) => {
   const selectHeight = popperHeight ? `${popperHeight}px` : 'auto'
   const theme = useTheme()
-  const [selected, setSelected] = useState<[]>([])
+  const [selected, setSelected] = useState<Options>([])
   const [showItems, setShowItems] = useState(false)
 
-  // Add an ESLint exception until there is a solution
-  // eslint-disable-next-line
-  const handleChange = (selectedItems: any) => {
+  const handleChange = (selectedItems: Options) => {
     onAddItem(selectedItems)
     setSelected(selectedItems)
   }
@@ -143,17 +143,11 @@ export const MultiSelectList = ({
           multiple
           disabled={disabled}
           options={items.map((item) => item)}
-          // Add an ESLint exception until there is a solution
-          // eslint-disable-next-line
-          getOptionLabel={(option: any) => option[keyTitle]}
+          getOptionLabel={(option) => option[keyTitle]}
           value={selected}
           filterOptions={filterOptions}
-          // Add an ESLint exception until there is a solution
-          // eslint-disable-next-line
-          renderTags={(selectedItems: any[], getTagProps) =>
-            // Add an ESLint exception until there is a solution
-            // eslint-disable-next-line
-            selectedItems.map((option: any, index: number) => (
+          renderTags={(selectedItems, getTagProps) =>
+            selectedItems.map((option, index: number) => (
               <Chip
                 {...getTagProps({ index })}
                 className="cx-multi-select__chip"

--- a/src/components/basic/SelectList/index.tsx
+++ b/src/components/basic/SelectList/index.tsx
@@ -28,9 +28,9 @@ import uniqueId from 'lodash/uniqueId'
 import isEqual from 'lodash/isEqual'
 import { useEffect, useState } from 'react'
 
+type Option = Record<string, string | number | null>
 interface SelectListProps extends Omit<TextFieldProps, 'variant'> {
-  // eslint-disable-next-line
-  items: any
+  items: Option[]
   label: string
   placeholder: string
   keyTitle: string
@@ -38,10 +38,9 @@ interface SelectListProps extends Omit<TextFieldProps, 'variant'> {
   variant?: 'filled'
   clearText?: string
   noOptionsText?: string
-  defaultValue?: unknown
+  defaultValue?: Option
   disableClearable?: boolean
-  // eslint-disable-next-line
-  onChangeItem: (items: any) => void
+  onChangeItem: (items: Option) => void
 }
 
 export const SelectList = ({
@@ -63,16 +62,13 @@ export const SelectList = ({
   onChangeItem,
 }: SelectListProps) => {
   const selectHeight = popperHeight ? `${popperHeight}px` : 'auto'
-  // Add an ESLint exception until there is a solution
-  // eslint-disable-next-line
-  const [selected, setSelected] = useState<any>(defaultValue || {})
+  const [selected, setSelected] = useState<Option>(defaultValue ?? {})
 
   useEffect(() => {
-    setSelected(defaultValue)
+    setSelected(defaultValue ?? {})
   }, [JSON.stringify(defaultValue)])
 
-  // eslint-disable-next-line
-  const handleChange = (newValue: any) => {
+  const handleChange = (newValue: Option) => {
     if (newValue) {
       setSelected(newValue)
       onChangeItem(newValue)
@@ -90,10 +86,8 @@ export const SelectList = ({
       noOptionsText={noOptionsText}
       ListboxProps={{ style: { maxHeight: selectHeight } }}
       disabled={disabled}
-      // eslint-disable-next-line
-      options={items.map((item: any) => item)}
-      // eslint-disable-next-line
-      getOptionLabel={(option) => option[keyTitle] || ''}
+      options={items.map((item) => item)}
+      getOptionLabel={(option: Option) => (option[keyTitle] as string) || ''}
       onChange={(_event, nextValue) => {
         handleChange(nextValue ?? {})
       }}
@@ -101,7 +95,10 @@ export const SelectList = ({
       renderOption={(props, option, { inputValue }) => (
         <SelectOptions
           props={props}
-          parts={parse(option[keyTitle], match(option[keyTitle], inputValue))}
+          parts={parse(
+            option[keyTitle] as string,
+            match(option[keyTitle] as string, inputValue)
+          )}
           key={uniqueId('select-list-option')}
         />
       )}

--- a/src/components/basic/Table/PageLoadingTable.tsx
+++ b/src/components/basic/Table/PageLoadingTable.tsx
@@ -23,11 +23,15 @@ import { Table, type TableProps } from '.'
 import { LoadMoreButton } from '../Button/LoadMoreButton'
 import { hasMorePages, getMaxRows } from './components/Helper/helper'
 
-export interface PaginFetchArgs {
+export interface PaginFetchArgs<T> {
   page: number
-  // Add an ESLint exception until there is a solution
-  // eslint-disable-next-line
-  args?: any
+  args?:
+    | (T & {
+        v: number
+      })
+    | {
+        v: number
+      }
 }
 
 export interface PaginMeta {
@@ -47,7 +51,7 @@ export interface PageLoadingTableProps<Row, Args>
   loadLabel: string
   // Add an ESLint exception until there is a solution
   // eslint-disable-next-line
-  fetchHook: (paginArgs: PaginFetchArgs) => any
+  fetchHook: (paginArgs: PaginFetchArgs<Args>) => any
   fetchHookArgs?: Args
   fetchHookRefresh?: number
   allItems?: Row[]

--- a/src/components/basic/Table/PageLoadingTable.tsx
+++ b/src/components/basic/Table/PageLoadingTable.tsx
@@ -23,15 +23,11 @@ import { LoadMoreButton } from '../Button/LoadMoreButton'
 import { hasMorePages, getMaxRows } from './components/Helper/helper'
 import { Table, type TableProps } from '.'
 
-export interface PaginFetchArgs<T> {
+export interface PaginFetchArgs {
   page: number
-  args?:
-    | (T & {
-        v: number
-      })
-    | {
-        v: number
-      }
+  // Add an ESLint exception until there is a solution
+  // eslint-disable-next-line
+  args?: any
 }
 
 export interface PaginMeta {
@@ -51,7 +47,7 @@ export interface PageLoadingTableProps<Row, Args>
   loadLabel: string
   // Add an ESLint exception until there is a solution
   // eslint-disable-next-line
-  fetchHook: (paginArgs: PaginFetchArgs<Args>) => any
+  fetchHook: (paginArgs: PaginFetchArgs) => any
   fetchHookArgs?: Args
   fetchHookRefresh?: number
   allItems?: Row[]

--- a/src/components/basic/Table/index.tsx
+++ b/src/components/basic/Table/index.tsx
@@ -246,8 +246,7 @@ export const Table = ({
                 outline: 'none',
               },
           }}
-          // eslint-disable-next-line
-          getRowId={(row) => row.id}
+          getRowId={(row) => row.id as GridRowId}
           components={{
             Toolbar: () => toolbarView(),
             NoRowsOverlay,


### PR DESCRIPTION
## Description

- **Replaced `any` Type**: Updated the code to use specific types instead of `any`.
- **Removed ESLint Comments**: Deleted unnecessary `eslint-disable-next-line` comments that were bypassing type-related linting rules.

## Why

- Replacing `any` type with specific types improves type safety, helps catch errors early, and makes the code easier to read and maintain.
 
## Issue

[311](https://github.com/eclipse-tractusx/portal-shared-components/issues/311)

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
