### PR TITLE
fix(new toggle switch): default text removed and ui issue fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catena-x/portal-shared-components",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Catena-X Portal Shared Components",
   "author": "Catena-X Contributors",
   "license": "Apache-2.0",

--- a/src/components/basic/ToggleSwitch/ToggleSwitch.scss
+++ b/src/components/basic/ToggleSwitch/ToggleSwitch.scss
@@ -18,55 +18,13 @@
  ********************************************************************************/
 
 .toggle-switch {
-  width: 60px;
-  height: 30px;
-  align-items: center;
-  justify-content: center;
-  padding: 0px;
-
-  & .MuiSwitch-switchBase {
-    top: 6px;
-    left: 7px;
-    color: #fff;
-
+  .MuiSwitch-switchBase {
     &.Mui-checked {
       transform: translateX(28px);
     }
 
     &.Mui-disabled {
       color: #d9d9d9;
-    }
-  }
-
-  & .MuiSwitch-thumb {
-    width: 26px;
-    height: 26px;
-    background-color: #fff;
-    position: absolute;
-  }
-
-  & .MuiSwitch-track {
-    border-radius: 15px;
-    background-color: #ff0000;
-    height: 30px;
-    opacity: 1;
-
-    &::before {
-      position: absolute;
-      content: 'ON';
-      font-size: 12px;
-      left: 5px;
-      top: 6px;
-      color: #000;
-    }
-
-    &::after {
-      position: absolute;
-      content: 'OFF';
-      font-size: 12px;
-      right: 5px;
-      top: 6px;
-      color: #000;
     }
   }
 

--- a/src/components/basic/ToggleSwitch/ToggleSwitch.stories.tsx
+++ b/src/components/basic/ToggleSwitch/ToggleSwitch.stories.tsx
@@ -39,8 +39,8 @@ const Template: ComponentStory<typeof Component> = (
   return <Component {...args} checked={checked} onChange={handleToggleChange} />
 }
 
-export const Default = Template.bind({})
-Default.args = {
+export const ToggleSwitch = Template.bind({})
+ToggleSwitch.args = {
   disabled: false,
-  isHoverEnabled: false,
+  hoverEnabled: false,
 }

--- a/src/components/basic/ToggleSwitch/index.tsx
+++ b/src/components/basic/ToggleSwitch/index.tsx
@@ -34,7 +34,7 @@ export const ToggleSwitch = ({
   onChange,
   disabled = false,
   hoverEnabled = false,
-  tooltipText = 'hdhdhddh',
+  tooltipText = '',
 }: ToggleSwitchProps) => {
   const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
     if (e.key === 'Enter' || e.key === ' ') {
@@ -64,9 +64,47 @@ export const ToggleSwitch = ({
         inputProps={{ 'aria-label': 'controlled' }}
         disabled={disabled}
         onKeyDown={handleKeyDown}
+        sx={{
+          width: '60px',
+          height: '30px',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: 0,
+          '& .MuiSwitch-switchBase': {
+            top: '6px',
+            left: '7px',
+            color: '#fff',
+          },
+          '& .MuiSwitch-thumb': {
+            width: '26px',
+            height: '26px',
+            backgroundColor: '#fff',
+            position: 'absolute',
+          },
+          '& .MuiSwitch-track': {
+            borderRadius: '15px',
+            backgroundColor: checked ? '#5bb52e' : '#ff0000',
+            height: '30px',
+            opacity: 1,
+            '&::before': {
+              content: '"ON"',
+              position: 'absolute',
+              left: '5px',
+              top: '6px',
+              fontSize: '12px',
+              color: '#000',
+            },
+            '&::after': {
+              content: '"OFF"',
+              position: 'absolute',
+              right: '5px',
+              top: '6px',
+              fontSize: '12px',
+              color: '#000',
+            },
+          },
+        }}
       />
     </Tooltip>
   )
 }
-
-export default ToggleSwitch


### PR DESCRIPTION
## Description

Need to remove default text from tooltipText and ui issue need to fix on hard reload.

## Why

Default tooltip text not needed and ui should be consistent on hard reload

## Issue

https://github.com/eclipse-tractusx/portal-shared-components/issues/254

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally

