### PR TITLE
feature(cards): add clicked state on favorite icon in cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.6.2](https://github.com/eclipse-tractusx/portal-shared-components/compare/v3.6.1...v3.6.2) (2024-09-24)
+
+### Features
+
+- **favorite icons clicked state:** add clicked state on favorite icon in cards ([f191582](https://github.com/eclipse-tractusx/portal-shared-components/commit/f191582d571a034c44f850f0214b443ca0a7472d))
+
+
 ## [3.6.1](https://github.com/eclipse-tractusx/portal-shared-components/compare/v3.6.0...v3.6.1) (2024-09-17)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catena-x/portal-shared-components",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "description": "Catena-X Portal Shared Components",
   "author": "Catena-X Contributors",
   "license": "Apache-2.0",

--- a/src/components/content/Cards/Card.tsx
+++ b/src/components/content/Cards/Card.tsx
@@ -248,7 +248,7 @@ export const Card = ({
       >
         {showFavIcon && (
           <Box
-            className="cx-card__icon"
+            className={`cx-card__icon ${addButtonClicked ? 'cx-card__icon--active' : 'cx-card__icon--inactive'}`}
             sx={{
               padding: '10px',
             }}

--- a/src/components/content/Cards/index.tsx
+++ b/src/components/content/Cards/index.tsx
@@ -141,7 +141,7 @@ export const Cards = ({
         <Card
           {...settings}
           {...item}
-          key={uniqueId('Cards')}
+          key={item.id}
           onClick={() => {
             onCardClick(item)
           }}


### PR DESCRIPTION
## Description

Please include a summary of the change.

## Why

To incorporate support for the Favorite Icon clicked state on the AppCard, updates need to be made at the Application level.

## Issue

https://github.com/eclipse-tractusx/portal-shared-components/issues/327

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
