### PR TITLE
fix(new toggle switch): remove the on off text

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -19,7 +19,7 @@ npm/npmjs/-/arg/4.1.3, MIT, approved, clearlydefined
 npm/npmjs/-/argparse/1.0.10, MIT, approved, #2174
 npm/npmjs/-/argparse/2.0.1, Python-2.0, approved, CQ22954
 npm/npmjs/-/aria-query/5.1.3, Apache-2.0, approved, clearlydefined
-npm/npmjs/-/aria-query/5.3.0, Apache-2.0, approved, clearlydefined
+npm/npmjs/-/aria-query/5.3.0, Apache-2.0, approved, #16427
 npm/npmjs/-/array-buffer-byte-length/1.0.1, MIT, approved, #7548
 npm/npmjs/-/array-flatten/1.1.1, MIT, approved, clearlydefined
 npm/npmjs/-/array-includes/3.1.8, MIT, approved, #4577
@@ -160,7 +160,7 @@ npm/npmjs/-/domexception/4.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/ee-first/1.1.1, MIT, approved, clearlydefined
 npm/npmjs/-/electron-to-chromium/1.4.715, ISC, approved, #1950
 npm/npmjs/-/electron-to-chromium/1.4.828, ISC, approved, #1950
-npm/npmjs/-/electron-to-chromium/1.5.6, ISC, approved, clearlydefined
+npm/npmjs/-/electron-to-chromium/1.5.6, ISC, approved, #16197
 npm/npmjs/-/emittery/0.13.1, MIT, approved, clearlydefined
 npm/npmjs/-/emoji-regex/8.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/encodeurl/1.0.2, MIT, approved, clearlydefined
@@ -285,7 +285,7 @@ npm/npmjs/-/has-tostringtag/1.0.2, MIT, approved, #13161
 npm/npmjs/-/hasown/2.0.2, MIT, approved, #11097
 npm/npmjs/-/hast-util-heading-rank/3.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/hast-util-is-element/3.0.0, MIT, approved, clearlydefined
-npm/npmjs/-/hast-util-to-string/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/hast-util-to-string/3.0.0, MIT, approved, #16416
 npm/npmjs/-/he/1.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/hoist-non-react-statics/3.3.2, BSD-3-Clause, approved, clearlydefined
 npm/npmjs/-/html-encoding-sniffer/3.0.0, MIT, approved, clearlydefined
@@ -713,7 +713,7 @@ npm/npmjs/-/universalify/2.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/unpipe/1.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/unplugin/1.10.0, MIT, approved, #14018
 npm/npmjs/-/update-browserslist-db/1.0.13, MIT, approved, #8237
-npm/npmjs/-/update-browserslist-db/1.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/update-browserslist-db/1.1.0, MIT, approved, #16405
 npm/npmjs/-/uri-js/4.4.1, BSD-2-Clause, approved, #1086
 npm/npmjs/-/url-parse/1.5.10, MIT, approved, clearlydefined
 npm/npmjs/-/util-deprecate/1.0.2, MIT, approved, #5885
@@ -926,16 +926,16 @@ npm/npmjs/@emotion/babel-plugin/11.11.0, MIT, approved, #8386
 npm/npmjs/@emotion/cache/11.11.0, MIT, approved, #8401
 npm/npmjs/@emotion/hash/0.9.1, MIT, approved, #8394
 npm/npmjs/@emotion/hash/0.9.2, MIT, approved, #8394
-npm/npmjs/@emotion/is-prop-valid/1.3.0, MIT, approved, clearlydefined
+npm/npmjs/@emotion/is-prop-valid/1.3.0, MIT AND (BSD-2-Clause AND MIT), approved, #16339
 npm/npmjs/@emotion/memoize/0.8.1, MIT, approved, #8408
 npm/npmjs/@emotion/memoize/0.9.0, MIT, approved, clearlydefined
 npm/npmjs/@emotion/react/11.11.4, MIT AND (BSD-3-Clause AND MIT), approved, #8931
-npm/npmjs/@emotion/serialize/1.3.0, MIT, approved, clearlydefined
+npm/npmjs/@emotion/serialize/1.3.0, MIT AND (BSD-2-Clause AND MIT), approved, #16340
 npm/npmjs/@emotion/sheet/1.2.2, MIT, approved, #8389
 npm/npmjs/@emotion/styled/11.11.5, MIT, approved, clearlydefined
 npm/npmjs/@emotion/unitless/0.9.0, MIT, approved, clearlydefined
 npm/npmjs/@emotion/use-insertion-effect-with-fallbacks/1.0.1, MIT, approved, #8419
-npm/npmjs/@emotion/utils/1.4.0, MIT, approved, clearlydefined
+npm/npmjs/@emotion/utils/1.4.0, MIT AND (BSD-2-Clause AND MIT), approved, #16344
 npm/npmjs/@emotion/weak-memoize/0.3.1, MIT, approved, #8402
 npm/npmjs/@esbuild/aix-ppc64/0.21.5, MIT, approved, clearlydefined
 npm/npmjs/@esbuild/android-arm/0.21.5, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #15369
@@ -962,7 +962,7 @@ npm/npmjs/@esbuild/win32-ia32/0.21.5, MIT, approved, clearlydefined
 npm/npmjs/@esbuild/win32-x64/0.21.5, MIT, approved, clearlydefined
 npm/npmjs/@eslint-community/eslint-utils/4.4.0, MIT, approved, #15285
 npm/npmjs/@eslint-community/regexpp/4.10.0, MIT, approved, clearlydefined
-npm/npmjs/@eslint-community/regexpp/4.11.0, MIT, approved, clearlydefined
+npm/npmjs/@eslint-community/regexpp/4.11.0, MIT AND BSD-3-Clause, approved, #16257
 npm/npmjs/@eslint/eslintrc/2.1.4, MIT, approved, #9908
 npm/npmjs/@eslint/js/8.57.0, MIT, approved, clearlydefined
 npm/npmjs/@floating-ui/core/1.6.0, MIT, approved, clearlydefined
@@ -1015,7 +1015,7 @@ npm/npmjs/@nodelib/fs.scandir/2.1.5, MIT, approved, clearlydefined
 npm/npmjs/@nodelib/fs.stat/2.0.5, MIT, approved, clearlydefined
 npm/npmjs/@nodelib/fs.walk/1.2.8, MIT, approved, clearlydefined
 npm/npmjs/@popperjs/core/2.11.8, MIT, approved, clearlydefined
-npm/npmjs/@rollup/pluginutils/5.1.0, MIT, approved, clearlydefined
+npm/npmjs/@rollup/pluginutils/5.1.0, MIT, approved, #16428
 npm/npmjs/@rollup/rollup-android-arm-eabi/4.21.2, MIT, approved, clearlydefined
 npm/npmjs/@rollup/rollup-android-arm64/4.21.2, MIT, approved, clearlydefined
 npm/npmjs/@rollup/rollup-darwin-arm64/4.21.2, MIT, approved, clearlydefined
@@ -1117,8 +1117,8 @@ npm/npmjs/@types/minimatch/5.1.2, MIT, approved, clearlydefined
 npm/npmjs/@types/node/18.19.26, MIT, approved, #12897
 npm/npmjs/@types/node/20.11.30, MIT, approved, #13826
 npm/npmjs/@types/parse-json/4.0.2, MIT, approved, clearlydefined
-npm/npmjs/@types/prop-types/15.7.11, MIT, approved, clearlydefined
-npm/npmjs/@types/prop-types/15.7.12, MIT, approved, clearlydefined
+npm/npmjs/@types/prop-types/15.7.11, MIT, approved, #16176
+npm/npmjs/@types/prop-types/15.7.12, MIT, approved, #16176
 npm/npmjs/@types/qs/6.9.14, MIT, approved, #14071
 npm/npmjs/@types/range-parser/1.2.7, MIT, approved, #10795
 npm/npmjs/@types/react-dom/18.2.22, MIT, approved, #8256
@@ -1126,7 +1126,7 @@ npm/npmjs/@types/react-dom/18.3.0, MIT, approved, clearlydefined
 npm/npmjs/@types/react-slick/0.23.13, MIT, approved, #11666
 npm/npmjs/@types/react-transition-group/4.4.10, MIT, approved, #8416
 npm/npmjs/@types/react/18.2.67, MIT, approved, #8234
-npm/npmjs/@types/react/18.3.3, MIT, approved, clearlydefined
+npm/npmjs/@types/react/18.3.3, MIT, approved, #16412
 npm/npmjs/@types/resolve/1.20.6, MIT, approved, clearlydefined
 npm/npmjs/@types/scheduler/0.16.8, MIT, approved, #7582
 npm/npmjs/@types/semver/7.5.8, MIT, approved, #10842

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catena-x/portal-shared-components",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "description": "Catena-X Portal Shared Components",
   "author": "Catena-X Contributors",
   "license": "Apache-2.0",

--- a/src/components/basic/ToggleSwitch/index.tsx
+++ b/src/components/basic/ToggleSwitch/index.tsx
@@ -87,7 +87,6 @@ export const ToggleSwitch = ({
             height: '30px',
             opacity: 1,
             '&::before': {
-              content: '"ON"',
               position: 'absolute',
               left: '5px',
               top: '6px',
@@ -95,7 +94,6 @@ export const ToggleSwitch = ({
               color: '#000',
             },
             '&::after': {
-              content: '"OFF"',
               position: 'absolute',
               right: '5px',
               top: '6px',


### PR DESCRIPTION
## Description

Removed the on off text from toggle switch

## Why

On and Off text not required any more from demo feedback

## Issue

https://github.com/eclipse-tractusx/portal-shared-components/issues/254

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
