### PR TITLE
fix(UI): card component spaces

### DIFF
--- a/src/components/content/Cards/Card.tsx
+++ b/src/components/content/Cards/Card.tsx
@@ -312,10 +312,6 @@ export const Card = ({
         <Box
           sx={{
             marginBottom: '20px',
-            overflow: 'hidden',
-            display: '-webkit-box',
-            WebkitBoxOrient: 'vertical',
-            WebkitLineClamp: '6',
           }}
           className="cx-card__content--wrapper"
         >

--- a/src/components/content/Cards/Card.tsx
+++ b/src/components/content/Cards/Card.tsx
@@ -310,7 +310,13 @@ export const Card = ({
           )}
         </Box>
         <Box
-          sx={{ marginBottom: '20px' }}
+          sx={{
+            marginBottom: '20px',
+            overflow: 'hidden',
+            display: '-webkit-box',
+            WebkitBoxOrient: 'vertical',
+            WebkitLineClamp: '6',
+          }}
           className="cx-card__content--wrapper"
         >
           {statusText && imageSize === 'small' && showStatus && (

--- a/src/components/content/Cards/CardContent.tsx
+++ b/src/components/content/Cards/CardContent.tsx
@@ -40,17 +40,24 @@ export const CardContent = ({
 }: CardContentProps) => {
   return (
     <Box sx={{ padding: '20px' }} className="cx-card__content">
-      <Box sx={{ height: '35px' }}>
+      <Box sx={{ height: '35px', mb: '10px' }}>
         {subtitle && (
           <Typography
             variant="label3"
-            sx={{ color: 'text.tertiary', display: 'inline-block' }}
+            sx={{
+              color: 'text.tertiary',
+              overflow: 'hidden',
+              display: '-webkit-box',
+              WebkitBoxOrient: 'vertical',
+              WebkitLineClamp: '2',
+              lineHeight: '20px',
+            }}
           >
             {subtitle}
           </Typography>
         )}
       </Box>
-      <Box sx={{ height: '35px' }}>
+      <Box sx={{ height: '35px', mb: '10px' }}>
         <Typography
           variant="h5"
           sx={{
@@ -58,9 +65,10 @@ export const CardContent = ({
             overflow: 'hidden',
             textOverflow: 'ellipsis',
             whiteSpace: 'normal',
-            display: 'box',
-            lineClamp: '2',
-            boxOrient: 'vertical',
+            display: '-webkit-box',
+            WebkitLineClamp: '2',
+            WebkitBoxOrient: 'vertical',
+            lineHeight: '20px',
           }}
         >
           {title}

--- a/src/components/content/Cards/CardContent.tsx
+++ b/src/components/content/Cards/CardContent.tsx
@@ -39,7 +39,10 @@ export const CardContent = ({
   description,
 }: CardContentProps) => {
   return (
-    <Box sx={{ padding: '20px' }} className="cx-card__content">
+    <Box
+      sx={{ padding: '20px', overflowWrap: 'break-word' }}
+      className="cx-card__content"
+    >
       <Box sx={{ height: '35px', mb: '10px' }}>
         {subtitle && (
           <Typography

--- a/src/components/content/Cards/CardContent.tsx
+++ b/src/components/content/Cards/CardContent.tsx
@@ -88,7 +88,16 @@ export const CardContent = ({
         </Box>
       )}
       {description && (
-        <Typography variant="body3" sx={{ marginTop: 1.5 }}>
+        <Typography
+          variant="body3"
+          sx={{
+            marginTop: 1.5,
+            overflow: 'hidden',
+            display: '-webkit-box',
+            WebkitBoxOrient: 'vertical',
+            WebkitLineClamp: '2',
+          }}
+        >
           {description}
         </Typography>
       )}


### PR DESCRIPTION
## Description
Card component wasn't handling longer text description gracefully and some Label and typography elements spaces wasn't consistent to look appealing. I implemented some new css properties to make longer text transition in truncate and introduced margin around text elements.

## Why
The longer text cause broken UI and user can't read the rest of the information which was coming beneath the card component.

After fix:
![Screenshot 2024-09-30 at 10 24 02](https://github.com/user-attachments/assets/fa163b37-f2df-4044-8032-f26ffc7b961a)


## Issue
https://github.com/eclipse-tractusx/portal-shared-components/issues/335

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
