### PR TITLE
docs: align doc structure with TRG1

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+# Portal Shared Component Documentation
+
+This documentation provides guidelines and information for understanding and working with the **Portal Shared Component**. It includes the following document:
+
+1. [**Release process**](./admin/release-process/release-process.md)
+
+   The release process is divided into several steps to ensure that versioning, changelog updates, and publishing are conducted systematically.

--- a/docs/admin/release-process/release-process.md
+++ b/docs/admin/release-process/release-process.md
@@ -58,7 +58,7 @@ If the workflow is executed manually and there is no release commit but the pack
 
 ## Release Process Flow Diagram
 
-![Project Diagram](../static/release-process.png)
+![Project Diagram](../../static/release-process.png)
 
 ## Reference Documents
 


### PR DESCRIPTION
## Description

Adjust documentation structure to align with TRG1

## Why

To align document structure with TRG 1

## Issue

#315 

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally