### PR TITLE
chore(prettier-check): ignore changelog

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ storybook
 build
 dist
 public
+CHANGELOG.md


### PR DESCRIPTION
## Description

release please uses * for lists, prettier wants -, as the changelog is autogenerated since https://github.com/eclipse-tractusx/portal-shared-components/pull/263, I'd just exclude it from the prettier check

## Why

prettier check fails, example PR https://github.com/eclipse-tractusx/portal-shared-components/pull/329

## Issue

n/a

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own changes
- [x] I have successfully tested my changes
