### PR TITLE
fix: convert status to lowerCase

### DIFF
--- a/src/components/content/Cards/CardChip.tsx
+++ b/src/components/content/Cards/CardChip.tsx
@@ -73,7 +73,8 @@ const statusStyles: Record<StatusVariants | 'default', ChipStyle> = {
 export const CardChip = ({ status, statusText }: CardChipProps) => {
   const theme = useTheme()
   const { color, backgroundColor }: ChipStyle =
-    statusStyles[status ?? 'default'] || statusStyles.default
+    statusStyles[(status?.toLowerCase() as StatusVariants) ?? 'default'] ||
+    statusStyles.default
 
   return (
     <MuiChip


### PR DESCRIPTION
## Description

Convert status value to lowercase.

## Why
To fix this issue : Service overview shows only greyed out status labels
[#1231](https://github.com/eclipse-tractusx/portal-frontend/issues/1231)

## Issue

#308 

## Checklist
- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally