### PR TITLE
fix: add statusText props in cardDecision to have proper text in chips

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -135,7 +135,7 @@ npm/npmjs/-/dom-helpers/5.2.1, MIT, approved, clearlydefined
 npm/npmjs/-/domexception/4.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/ee-first/1.1.1, MIT, approved, clearlydefined
 npm/npmjs/-/ejs/3.1.10, Apache-2.0, approved, #1373
-npm/npmjs/-/electron-to-chromium/1.5.29, ISC, approved, #16184
+npm/npmjs/-/electron-to-chromium/1.5.29, ISC, approved, #16342
 npm/npmjs/-/emittery/0.13.1, MIT, approved, clearlydefined
 npm/npmjs/-/emoji-regex/8.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/encodeurl/1.0.2, MIT, approved, clearlydefined

--- a/src/components/content/Cards/CardDecision.stories.tsx
+++ b/src/components/content/Cards/CardDecision.stories.tsx
@@ -39,12 +39,14 @@ const items = [
     provider: 'Bayerische Motorenwerke AG',
     name: 'Logistics Network, Material Traceability (LBN-MT)',
     status: StatusVariants.release,
+    statusText: 'Released',
   },
   {
     appId: '123',
     provider: 'Catena-X',
     name: 'DTC-Translator',
     status: StatusVariants.active,
+    statusText: 'Active',
   },
 ]
 

--- a/src/components/content/Cards/CardDecision.tsx
+++ b/src/components/content/Cards/CardDecision.tsx
@@ -28,6 +28,7 @@ export interface AppContent {
   name?: string
   provider: string
   status: StatusVariants
+  statusText?: string
   id?: string
   title?: string
 }
@@ -135,7 +136,10 @@ export const CardDecision = ({
                 sx={{ marginBottom: '10px' }}
                 className="cx-card__decision--chip"
               >
-                <CardChip status={item.status} statusText={item.status} />
+                <CardChip
+                  status={item.status}
+                  statusText={item.statusText ?? item.status}
+                />
               </Box>
               {(item.status?.toLowerCase() as StatusVariants) !==
                 StatusVariants.active && (


### PR DESCRIPTION
## Description
- Added a statusText props to display text in chips

## Why
- Some text like **In Review** is getting displayed like this **IN_REVIEW**
- ![image](https://github.com/user-attachments/assets/956b71e9-b7e4-40b2-be74-fcbc23405eae)


## Issue
- https://github.com/eclipse-tractusx/portal-shared-components/issues/352

## Checklist

- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
