### PR TITLE
feat: added image object in horizontal card component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@
 
 - simplify and automate release versioning ([3824c8c](https://github.com/eclipse-tractusx/portal-shared-components/commit/3824c8ccec94cbc5856c7094d92d7db21058f304))
 - **table:** support pagination in table component ([fc362a0](https://github.com/eclipse-tractusx/portal-shared-components/commit/fc362a08d2c881273f1cc3f9dd07cf26ad099547))
+- Horizontalcard component support image object(https://github.com/eclipse-tractusx/portal-shared-components/pull/355) 
 
 ## 3.1.2
 

--- a/src/components/content/Cards/CardHorizontal.stories.tsx
+++ b/src/components/content/Cards/CardHorizontal.stories.tsx
@@ -41,8 +41,13 @@ CardHorizontal.args = {
   description:
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
   borderRadius: 20,
-  imagePath: '',
-  imageAlt: 'App Card ',
+  image: {
+    src: 'https://raw.githubusercontent.com/eclipse-tractusx/portal-assets/main/public/assets/images/logos/cx-short.svg',
+    alt: 'alt text',
+    style: {
+      color: 'red',
+    },
+  },
   status: StatusVariants.release,
   statusText: 'In Release',
   buttonText: 'Details',

--- a/src/components/content/Cards/CardHorizontal.tsx
+++ b/src/components/content/Cards/CardHorizontal.tsx
@@ -20,23 +20,29 @@
 
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown'
 import { Box, useTheme } from '@mui/material'
-import { useRef } from 'react'
-import { LogoGrayData } from '../../basic/Image'
+import { useRef, type CSSProperties } from 'react'
+import { Image, LogoGrayData } from '../../basic/Image'
 import { Typography } from '../../basic/Typography'
 import { type CardChipProps } from './CardChip'
+
+interface ICardImage {
+  src: string
+  alt?: string
+  style?: CSSProperties
+}
 
 interface CardHorizontalProps extends CardChipProps {
   label: string
   title: string
   subTitle?: string
   borderRadius: number
-  imagePath: string
-  imageAlt?: string
   description?: string
   backgroundColor?: string
   buttonText?: string
   onBtnClick?: React.MouseEventHandler
   expandOnHover?: boolean
+  image: ICardImage
+  imageLoader?: (src: string) => Promise<ArrayBuffer>
 }
 
 export const CardHorizontal = ({
@@ -44,9 +50,6 @@ export const CardHorizontal = ({
   title,
   subTitle,
   borderRadius = 0,
-  imagePath,
-  // @ts-expect-error keep for backward compatibility
-  imageAlt,
   description,
   // @ts-expect-error keep for backward compatibility
   status,
@@ -55,6 +58,8 @@ export const CardHorizontal = ({
   buttonText,
   onBtnClick,
   backgroundColor,
+  image,
+  imageLoader,
   // @ts-expect-error keep for backward compatibility
   expandOnHover = false,
 }: CardHorizontalProps) => {
@@ -76,19 +81,14 @@ export const CardHorizontal = ({
         },
       }}
     >
-      <Box
-        className="cx-card__horizontal--left"
-        sx={{
-          flex: '0 0 33.333333%',
-          maxWidth: '33.333333%',
-          minHeight: '200px',
-          backgroundImage: `url(${imagePath || LogoGrayData})`,
-          backgroundRepeat: 'no-repeat',
-          backgroundSize: 'cover',
-          backgroundPosition: 'center',
-          backgroundColor: theme.palette.accent.accent02,
-        }}
-      />
+      {image && (
+        <Image
+          src={image?.src ?? LogoGrayData}
+          alt={image?.alt}
+          loader={imageLoader}
+          style={{ ...image?.style }}
+        />
+      )}
       <Box
         className="cx-card__horizontal--right"
         sx={{


### PR DESCRIPTION
## Description
Removed the Box element for the image inside HorizontalCard component and replaced with Image component. 

## Why
HorizontalComponent should have the logic to handle the loader function and other properties similarly like we already have in Card Componet as an example.

## Issue
https://github.com/eclipse-tractusx/portal-shared-components/issues/356


Please delete options that are not relevant.
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
