### PR TITLE
fix(table): fix table error message

### DIFF
--- a/src/components/basic/Table/index.tsx
+++ b/src/components/basic/Table/index.tsx
@@ -191,7 +191,7 @@ export const Table = ({
   }
 
   const renderErrorMessage = () => {
-    if (error == null) {
+    if (rowsCount === 0 || error == null) {
       return <Typography variant="body2">{noRowsMsg ?? 'No rows'}</Typography>
     }
     if (error.status >= 400 && error.status < 500) {


### PR DESCRIPTION
## Description

Update table error message for rowsCount.

## Why

When the rowsCount is 0, it does not display noRowsMsg or default message in table.

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/1148

## Checklist

Please delete options that are not relevant.

- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed a self-review of my own code
- [ ] I have successfully tested my changes locally