### PR TITLE
chore: modify dependencies check to run only on yarn.lock updates

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -22,8 +22,12 @@ name: Check Dependencies
 on:
   push:
     branches: [main]
+    paths:
+      - yarn.lock
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - yarn.lock
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Description
- Modify dependencies check to run only on yarn.lock updates

## Why

https://github.com/orgs/eclipse-tractusx/projects/61/views/1?pane=issue&itemId=86504502

## Issue
#382 

## Checklist

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally