### PR TITLE
ci: modify dependencies check to run on DEPENDENCIES updates

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -24,10 +24,14 @@ on:
     branches: [main]
     paths:
       - yarn.lock
+      - DEPENDENCIES
+      - .github/workflows/dependencies.yaml
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
       - yarn.lock
+      - DEPENDENCIES
+      - .github/workflows/dependencies.yaml
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Description

Also trigger dependencies.yaml workflow on changes to dependencies.yaml and DEPENDENCIES file.

## Why

Prevent wrong/accidental changes to DEPENDENCIES file. Improvement to changes in eclipse-tractusx/portal-shared-components#384.

## Issue

Refs: eclipse-tractusx/portal-shared-components#382

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have performed a self-review of my own code
