### PR TITLE
fix(react): replace first-child pseudo class

### DIFF
--- a/src/components/basic/CategoryDivider/index.tsx
+++ b/src/components/basic/CategoryDivider/index.tsx
@@ -47,7 +47,7 @@ export const CategoryDivider = ({
         display: 'flex',
         marginBottom: '52px',
         marginTop: '52px',
-        '&:first-child': {
+        '&:first-of-type': {
           marginTop: '0',
         },
       }}

--- a/src/components/basic/StaticTable/style.scss
+++ b/src/components/basic/StaticTable/style.scss
@@ -53,7 +53,7 @@
   td {
     border-bottom: 5px solid #e0e1e2;
     padding: 10px 15px;
-    :first-child {
+    :first-of-type {
       border-top: 1px solid #e0e1e2;
     }
   }


### PR DESCRIPTION
## Description

Fixes removing react warnings

## Why

Implementation flaws caused warnings in dev mode

## Issue

[portal-frontend #1269](https://github.com/eclipse-tractusx/portal-frontend/issues/1269)

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally