### PR TITLE
feat: Card Decision prop to shortLegalName

### DIFF
--- a/src/components/content/Cards/CardDecision.tsx
+++ b/src/components/content/Cards/CardDecision.tsx
@@ -26,7 +26,7 @@ import { CardChip, StatusVariants } from './CardChip'
 export interface AppContent {
   appId?: string
   name?: string
-  provider: string
+  legalShortName: string
   status: StatusVariants
   statusText?: string
   id?: string
@@ -130,7 +130,7 @@ export const CardDecision = ({
                   height: '48px',
                 }}
               >
-                {item.provider}
+                {item.legalShortName}
               </Typography>
               <Box
                 sx={{ marginBottom: '10px' }}


### PR DESCRIPTION
## Description
Updated Card Decision component to accept prop of shortLegalName instead of provider prop for Portal.

## Why
Businesses need to differentiate between their long legal name and short legal name. The short legal name should be concise (e.g., 'XYZ' for 'XYZ GmbH') and easier to use in the UI instead of the full name.

## Issue
https://github.com/eclipse-tractusx/portal-shared-components/issues/422

## Checklist
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
