### PR TITLE
ci(yarn): fail pr checks if deleted package was not applied to yarn.lock

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -40,8 +40,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      # Install Dependencies
+      # Using --frozen-lockfile first to fail fast if yarn.lock is out of sync
+      # Run a second time since yarn v1 frozen-lockfile does not notice removed dependencies
       - name: Install Dependencies
-        run: yarn --frozen-lockfile
+        run: |
+          yarn --frozen-lockfile
+          yarn
+
+      - name: Check for uncommitted files in working directory
+        run: |
+          git_status=$(git status --porcelain)
+          if [ -n "$git_status" ]; then
+            echo "Please commit changed files before running checks."
+            exit 1
+          else
+            echo "No modified files found."
+          fi
 
       - name: Prettier Checks
         run: yarn pretty:check


### PR DESCRIPTION
## Description

Add additional check in pr-checks to prevent uncommitted changes when improperly deleting packages.

## Why

Prevent de-sync of package.json and yarn.lock. Otherwise unintended package version changes could be included in builds.

## Issue

eclipse-tractusx/portal-frontend#1622

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
